### PR TITLE
fix indexer entrypoint

### DIFF
--- a/masp-indexer/block-filter/entrypoint.sh
+++ b/masp-indexer/block-filter/entrypoint.sh
@@ -18,4 +18,4 @@ do
     sleep 2
 done
 
-./block-index --internal 2
+./block-index --interval 2

--- a/masp-indexer/chain/entrypoint.sh
+++ b/masp-indexer/chain/entrypoint.sh
@@ -18,4 +18,4 @@ do
     sleep 2
 done
 
-./chain --internal 2
+./chain --interval 2


### PR DESCRIPTION
The masp indexer block-filter and chain failed to start due to the wrong option.