### PR TITLE
Refactoring workload #1

### DIFF
--- a/check/src/checks/mod.rs
+++ b/check/src/checks/mod.rs
@@ -99,7 +99,7 @@ trait DoCheck {
 }
 
 fn is_successful(checker: Checker, res: Result<(), String>) {
-    let details = if let Err(e) = res.clone() {
+    let details = if let Err(ref e) = res {
         let is_timeout = e.to_lowercase().contains("timed out");
         let is_connection_closed = e.to_lowercase().contains("connection closed before");
         if is_timeout {

--- a/workload/docker_run.sh
+++ b/workload/docker_run.sh
@@ -12,7 +12,7 @@ mkdir -p /opt/antithesis/test/v1/namada/wallet-$WORKLOAD_ID
 mkdir -p /opt/antithesis/test/v1/namada/masp-$WORKLOAD_ID
 
 if [[ ! -v ANTITHESIS_OUTPUT_DIR ]]; then
-    source /opt/antithesis/test/v1/namada/first_get_chainid.sh
+    source /opt/antithesis/test/v1/namada/init_script.sh
     if [ $? -eq 0 ] 
     then 
         echo "<OK> init" 
@@ -87,7 +87,7 @@ if [[ ! -v ANTITHESIS_OUTPUT_DIR ]]; then
             echo "<ERROR> unbond"
         fi
         
-        source /opt/antithesis/test/v1/namada/parallel_update_account.sh
+        source /opt/antithesis/test/v1/namada/parallel_driver_update_account.sh
         if [ $? -eq 0 ] 
         then 
             echo "<OK> update account" 

--- a/workload/scripts/init_script.sh
+++ b/workload/scripts/init_script.sh
@@ -34,6 +34,7 @@ done
 source /opt/antithesis/test/v1/namada/parallel_driver_create_wallet.sh
 source /opt/antithesis/test/v1/namada/parallel_driver_create_wallet.sh
 source /opt/antithesis/test/v1/namada/parallel_driver_create_wallet.sh
+source /opt/antithesis/test/v1/namada/parallel_driver_create_wallet.sh
 
 source /opt/antithesis/test/v1/namada/parallel_driver_faucet_transfer.sh
 source /opt/antithesis/test/v1/namada/parallel_driver_faucet_transfer.sh

--- a/workload/src/build/batch.rs
+++ b/workload/src/build/batch.rs
@@ -19,7 +19,7 @@ pub async fn build_bond_batch(
     max_size: usize,
     state: &mut State,
 ) -> Result<Vec<Task>, StepError> {
-    _build_batch(sdk, vec![BatchType::Bond], max_size, state).await
+    build_batch(sdk, vec![BatchType::Bond], max_size, state).await
 }
 
 pub async fn build_random_batch(
@@ -27,7 +27,7 @@ pub async fn build_random_batch(
     max_size: usize,
     state: &mut State,
 ) -> Result<Vec<Task>, StepError> {
-    _build_batch(
+    build_batch(
         sdk,
         vec![
             BatchType::TransparentTransfer,
@@ -44,7 +44,7 @@ pub async fn build_random_batch(
     .await
 }
 
-async fn _build_batch(
+async fn build_batch(
     sdk: &Sdk,
     possibilities: Vec<BatchType>,
     max_size: usize,

--- a/workload/src/build_checks/bond.rs
+++ b/workload/src/build_checks/bond.rs
@@ -1,6 +1,6 @@
 use tryhard::{backoff_strategies::ExponentialBackoff, NoOnRetry, RetryFutureConfig};
 
-use crate::{check::Check, entities::Alias, sdk::namada::Sdk, state::State};
+use crate::{check::Check, entities::Alias, sdk::namada::Sdk};
 
 pub async fn bond(
     sdk: &Sdk,
@@ -9,12 +9,11 @@ pub async fn bond(
     amount: u64,
     epoch: u64,
     retry_config: RetryFutureConfig<ExponentialBackoff, NoOnRetry>,
-    state: &State,
 ) -> Vec<Check> {
     let bond_check = if let Some(pre_bond) =
         super::utils::get_bond(sdk, source.clone(), validator.clone(), epoch, retry_config).await
     {
-        Check::BondIncrease(source, validator, pre_bond, amount, state.clone())
+        Check::BondIncrease(source, validator, pre_bond, amount)
     } else {
         return vec![];
     };

--- a/workload/src/build_checks/deactivate_validator.rs
+++ b/workload/src/build_checks/deactivate_validator.rs
@@ -4,14 +4,12 @@ use crate::{
     check::{Check, ValidatorStatus},
     entities::Alias,
     sdk::namada::Sdk,
-    state::State,
 };
 
 pub async fn deactivate_validator_build_checks(
     _sdk: &Sdk,
     alias: Alias,
     _retry_config: RetryFutureConfig<ExponentialBackoff, NoOnRetry>,
-    _state: &State,
 ) -> Vec<Check> {
     vec![Check::ValidatorStatus(alias, ValidatorStatus::Inactive)]
 }

--- a/workload/src/build_checks/faucet.rs
+++ b/workload/src/build_checks/faucet.rs
@@ -1,18 +1,17 @@
 use tryhard::{backoff_strategies::ExponentialBackoff, NoOnRetry, RetryFutureConfig};
 
-use crate::{check::Check, entities::Alias, sdk::namada::Sdk, state::State};
+use crate::{check::Check, entities::Alias, sdk::namada::Sdk};
 
 pub async fn faucet_build_check(
     sdk: &Sdk,
     target: Alias,
     amount: u64,
     retry_config: RetryFutureConfig<ExponentialBackoff, NoOnRetry>,
-    state: &State,
 ) -> Vec<Check> {
     let check = if let Some(pre_balance) =
         super::utils::get_balance(sdk, target.clone(), retry_config).await
     {
-        Check::BalanceTarget(target, pre_balance, amount, state.clone())
+        Check::BalanceTarget(target, pre_balance, amount)
     } else {
         return vec![];
     };

--- a/workload/src/build_checks/init_account.rs
+++ b/workload/src/build_checks/init_account.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeSet;
 
 use tryhard::{backoff_strategies::ExponentialBackoff, NoOnRetry, RetryFutureConfig};
 
-use crate::{check::Check, entities::Alias, sdk::namada::Sdk, state::State};
+use crate::{check::Check, entities::Alias, sdk::namada::Sdk};
 
 pub async fn init_account_build_checks(
     _sdk: &Sdk,
@@ -10,12 +10,6 @@ pub async fn init_account_build_checks(
     sources: BTreeSet<Alias>,
     threshold: u64,
     _retry_config: RetryFutureConfig<ExponentialBackoff, NoOnRetry>,
-    state: &State,
 ) -> Vec<Check> {
-    vec![Check::AccountExist(
-        alias,
-        threshold,
-        sources,
-        state.clone(),
-    )]
+    vec![Check::AccountExist(alias, threshold, sources)]
 }

--- a/workload/src/build_checks/proposal.rs
+++ b/workload/src/build_checks/proposal.rs
@@ -1,19 +1,16 @@
 use tryhard::{backoff_strategies::ExponentialBackoff, NoOnRetry, RetryFutureConfig};
 
-use crate::{
-    check::Check, constants::PROPOSAL_DEPOSIT, entities::Alias, sdk::namada::Sdk, state::State,
-};
+use crate::{check::Check, constants::PROPOSAL_DEPOSIT, entities::Alias, sdk::namada::Sdk};
 
 pub async fn proposal(
     sdk: &Sdk,
     source: Alias,
     retry_config: RetryFutureConfig<ExponentialBackoff, NoOnRetry>,
-    state: &State,
 ) -> Vec<Check> {
     let source_check = if let Some(pre_balance) =
         super::utils::get_balance(sdk, source.clone(), retry_config).await
     {
-        Check::BalanceSource(source, pre_balance, PROPOSAL_DEPOSIT, state.clone())
+        Check::BalanceSource(source, pre_balance, PROPOSAL_DEPOSIT)
     } else {
         return vec![];
     };

--- a/workload/src/build_checks/reactivate_validator.rs
+++ b/workload/src/build_checks/reactivate_validator.rs
@@ -4,14 +4,12 @@ use crate::{
     check::{Check, ValidatorStatus},
     entities::Alias,
     sdk::namada::Sdk,
-    state::State,
 };
 
 pub async fn reactivate_validator_build_checks(
     _sdk: &Sdk,
     alias: Alias,
     _retry_config: RetryFutureConfig<ExponentialBackoff, NoOnRetry>,
-    _state: &State,
 ) -> Vec<Check> {
     vec![Check::ValidatorStatus(alias, ValidatorStatus::Reactivating)]
 }

--- a/workload/src/build_checks/redelegate.rs
+++ b/workload/src/build_checks/redelegate.rs
@@ -1,6 +1,6 @@
 use tryhard::{backoff_strategies::ExponentialBackoff, NoOnRetry, RetryFutureConfig};
 
-use crate::{check::Check, entities::Alias, sdk::namada::Sdk, state::State};
+use crate::{check::Check, entities::Alias, sdk::namada::Sdk};
 
 #[allow(clippy::too_many_arguments)]
 pub async fn redelegate(
@@ -11,7 +11,6 @@ pub async fn redelegate(
     amount: u64,
     epoch: u64,
     retry_config: RetryFutureConfig<ExponentialBackoff, NoOnRetry>,
-    state: &State,
 ) -> Vec<Check> {
     let from_validator_bond_check = if let Some(pre_bond) = super::utils::get_bond(
         sdk,
@@ -22,13 +21,7 @@ pub async fn redelegate(
     )
     .await
     {
-        Check::BondDecrease(
-            source.clone(),
-            from_validator,
-            pre_bond,
-            amount,
-            state.clone(),
-        )
+        Check::BondDecrease(source.clone(), from_validator, pre_bond, amount)
     } else {
         return vec![];
     };
@@ -41,7 +34,7 @@ pub async fn redelegate(
     )
     .await
     {
-        Check::BondIncrease(source, to_validator, pre_bond, amount, state.clone())
+        Check::BondIncrease(source, to_validator, pre_bond, amount)
     } else {
         return vec![from_validator_bond_check];
     };

--- a/workload/src/build_checks/shielded_transfer.rs
+++ b/workload/src/build_checks/shielded_transfer.rs
@@ -1,6 +1,6 @@
 use tryhard::{backoff_strategies::ExponentialBackoff, NoOnRetry, RetryFutureConfig};
 
-use crate::{check::Check, entities::Alias, sdk::namada::Sdk, state::State};
+use crate::{check::Check, entities::Alias, sdk::namada::Sdk};
 
 pub async fn shielded_transfer(
     sdk: &Sdk,
@@ -9,12 +9,11 @@ pub async fn shielded_transfer(
     amount: u64,
     with_indexer: bool,
     _retry_config: RetryFutureConfig<ExponentialBackoff, NoOnRetry>,
-    state: &State,
 ) -> Vec<Check> {
     let source_check = if let Ok(Some(pre_balance)) =
         super::utils::get_shielded_balance(sdk, source.clone(), None, with_indexer).await
     {
-        Check::BalanceShieldedSource(source, pre_balance, amount, state.clone())
+        Check::BalanceShieldedSource(source, pre_balance, amount)
     } else {
         return vec![];
     };
@@ -22,7 +21,7 @@ pub async fn shielded_transfer(
     let target_check = if let Ok(Some(pre_balance)) =
         super::utils::get_shielded_balance(sdk, target.clone(), None, with_indexer).await
     {
-        Check::BalanceShieldedTarget(target, pre_balance, amount, state.clone())
+        Check::BalanceShieldedTarget(target, pre_balance, amount)
     } else {
         return vec![source_check];
     };

--- a/workload/src/build_checks/shielding.rs
+++ b/workload/src/build_checks/shielding.rs
@@ -1,6 +1,6 @@
 use tryhard::{backoff_strategies::ExponentialBackoff, NoOnRetry, RetryFutureConfig};
 
-use crate::{check::Check, entities::Alias, sdk::namada::Sdk, state::State};
+use crate::{check::Check, entities::Alias, sdk::namada::Sdk};
 
 pub async fn shielding(
     sdk: &Sdk,
@@ -9,12 +9,11 @@ pub async fn shielding(
     amount: u64,
     with_indexer: bool,
     retry_config: RetryFutureConfig<ExponentialBackoff, NoOnRetry>,
-    state: &State,
 ) -> Vec<Check> {
     let source_check = if let Some(pre_balance) =
         super::utils::get_balance(sdk, source.clone(), retry_config).await
     {
-        Check::BalanceSource(source, pre_balance, amount, state.clone())
+        Check::BalanceSource(source, pre_balance, amount)
     } else {
         return vec![];
     };
@@ -22,7 +21,7 @@ pub async fn shielding(
     let target_check = if let Ok(Some(pre_balance)) =
         super::utils::get_shielded_balance(sdk, target.clone(), None, with_indexer).await
     {
-        Check::BalanceShieldedTarget(target, pre_balance, amount, state.clone())
+        Check::BalanceShieldedTarget(target, pre_balance, amount)
     } else {
         return vec![source_check];
     };

--- a/workload/src/build_checks/transparent_transfer.rs
+++ b/workload/src/build_checks/transparent_transfer.rs
@@ -1,6 +1,6 @@
 use tryhard::{backoff_strategies::ExponentialBackoff, NoOnRetry, RetryFutureConfig};
 
-use crate::{check::Check, entities::Alias, sdk::namada::Sdk, state::State};
+use crate::{check::Check, entities::Alias, sdk::namada::Sdk};
 
 pub async fn transparent_transfer(
     sdk: &Sdk,
@@ -8,12 +8,11 @@ pub async fn transparent_transfer(
     target: Alias,
     amount: u64,
     retry_config: RetryFutureConfig<ExponentialBackoff, NoOnRetry>,
-    state: &State,
 ) -> Vec<Check> {
     let source_check = if let Some(pre_balance) =
         super::utils::get_balance(sdk, source.clone(), retry_config).await
     {
-        Check::BalanceSource(source, pre_balance, amount, state.clone())
+        Check::BalanceSource(source, pre_balance, amount)
     } else {
         return vec![];
     };
@@ -21,7 +20,7 @@ pub async fn transparent_transfer(
     let target_check = if let Some(pre_balance) =
         super::utils::get_balance(sdk, target.clone(), retry_config).await
     {
-        Check::BalanceTarget(target, pre_balance, amount, state.clone())
+        Check::BalanceTarget(target, pre_balance, amount)
     } else {
         return vec![source_check];
     };

--- a/workload/src/build_checks/unbond.rs
+++ b/workload/src/build_checks/unbond.rs
@@ -1,6 +1,6 @@
 use tryhard::{backoff_strategies::ExponentialBackoff, NoOnRetry, RetryFutureConfig};
 
-use crate::{check::Check, entities::Alias, sdk::namada::Sdk, state::State};
+use crate::{check::Check, entities::Alias, sdk::namada::Sdk};
 
 pub async fn unbond(
     sdk: &Sdk,
@@ -9,12 +9,11 @@ pub async fn unbond(
     amount: u64,
     epoch: u64,
     retry_config: RetryFutureConfig<ExponentialBackoff, NoOnRetry>,
-    state: &State,
 ) -> Vec<Check> {
     let bond_check = if let Some(pre_bond) =
         super::utils::get_bond(sdk, source.clone(), validator.clone(), epoch, retry_config).await
     {
-        Check::BondDecrease(source, validator, pre_bond, amount, state.clone())
+        Check::BondDecrease(source, validator, pre_bond, amount)
     } else {
         return vec![];
     };

--- a/workload/src/build_checks/unshielding.rs
+++ b/workload/src/build_checks/unshielding.rs
@@ -1,6 +1,6 @@
 use tryhard::{backoff_strategies::ExponentialBackoff, NoOnRetry, RetryFutureConfig};
 
-use crate::{check::Check, entities::Alias, sdk::namada::Sdk, state::State};
+use crate::{check::Check, entities::Alias, sdk::namada::Sdk};
 
 pub async fn unshielding(
     sdk: &Sdk,
@@ -9,12 +9,11 @@ pub async fn unshielding(
     amount: u64,
     with_indexer: bool,
     retry_config: RetryFutureConfig<ExponentialBackoff, NoOnRetry>,
-    state: &State,
 ) -> Vec<Check> {
     let source_check = if let Ok(Some(pre_balance)) =
         super::utils::get_shielded_balance(sdk, source.clone(), None, with_indexer).await
     {
-        Check::BalanceShieldedSource(source, pre_balance, amount, state.clone())
+        Check::BalanceShieldedSource(source, pre_balance, amount)
     } else {
         return vec![];
     };
@@ -22,7 +21,7 @@ pub async fn unshielding(
     let target_check = if let Some(pre_balance) =
         super::utils::get_balance(sdk, target.clone(), retry_config).await
     {
-        Check::BalanceTarget(target, pre_balance, amount, state.clone())
+        Check::BalanceTarget(target, pre_balance, amount)
     } else {
         return vec![source_check];
     };

--- a/workload/src/build_checks/update_account.rs
+++ b/workload/src/build_checks/update_account.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeSet;
 
 use tryhard::{backoff_strategies::ExponentialBackoff, NoOnRetry, RetryFutureConfig};
 
-use crate::{check::Check, entities::Alias, sdk::namada::Sdk, state::State};
+use crate::{check::Check, entities::Alias, sdk::namada::Sdk};
 
 pub async fn update_account_build_checks(
     _sdk: &Sdk,
@@ -10,12 +10,6 @@ pub async fn update_account_build_checks(
     sources: BTreeSet<Alias>,
     threshold: u64,
     _retry_config: RetryFutureConfig<ExponentialBackoff, NoOnRetry>,
-    state: &State,
 ) -> Vec<Check> {
-    vec![Check::AccountExist(
-        alias,
-        threshold,
-        sources,
-        state.clone(),
-    )]
+    vec![Check::AccountExist(alias, threshold, sources)]
 }

--- a/workload/src/check.rs
+++ b/workload/src/check.rs
@@ -3,7 +3,7 @@ use std::{
     fmt::{Display, Formatter},
 };
 
-use crate::{entities::Alias, state::State};
+use crate::entities::Alias;
 
 pub type Target = Alias;
 pub type PreBalance = namada_sdk::token::Amount;
@@ -31,13 +31,13 @@ impl Display for ValidatorStatus {
 #[derive(Clone, Debug)]
 pub enum Check {
     RevealPk(Target),
-    BalanceTarget(Target, PreBalance, Amount, State),
-    BalanceSource(Target, PreBalance, Amount, State),
-    BalanceShieldedTarget(Target, PreBalance, Amount, State),
-    BalanceShieldedSource(Target, PreBalance, Amount, State),
-    BondIncrease(Target, Address, PreBalance, Amount, State),
-    BondDecrease(Target, Address, PreBalance, Amount, State),
-    AccountExist(Target, Threshold, BTreeSet<Target>, State),
+    BalanceTarget(Target, PreBalance, Amount),
+    BalanceSource(Target, PreBalance, Amount),
+    BalanceShieldedTarget(Target, PreBalance, Amount),
+    BalanceShieldedSource(Target, PreBalance, Amount),
+    BondIncrease(Target, Address, PreBalance, Amount),
+    BondDecrease(Target, Address, PreBalance, Amount),
+    AccountExist(Target, Threshold, BTreeSet<Target>),
     IsValidatorAccount(Target),
     ValidatorStatus(Target, ValidatorStatus),
 }
@@ -46,25 +46,25 @@ impl Display for Check {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             Check::RevealPk(alias) => write!(f, "reveal/{}", alias.name),
-            Check::BalanceSource(target, _pre_balance, _amount, _) => {
+            Check::BalanceSource(target, _pre_balance, _amount) => {
                 write!(f, "balance/source/{}", target.name)
             }
-            Check::BalanceTarget(target, _pre_balance, _amount, _) => {
+            Check::BalanceTarget(target, _pre_balance, _amount) => {
                 write!(f, "balance/target/{}", target.name)
             }
-            Check::BalanceShieldedTarget(target, _pre_balance, _amount, _) => {
+            Check::BalanceShieldedTarget(target, _pre_balance, _amount) => {
                 write!(f, "balance-shielded/target/{}", target.name)
             }
-            Check::BalanceShieldedSource(target, _pre_balance, _amount, _) => {
+            Check::BalanceShieldedSource(target, _pre_balance, _amount) => {
                 write!(f, "balance-shielded/source/{}", target.name)
             }
-            Check::BondIncrease(source, validator, _pre_balance, _amount, _) => {
+            Check::BondIncrease(source, validator, _pre_balance, _amount) => {
                 write!(f, "bond/{}/{}/increase", source.name, validator)
             }
-            Check::BondDecrease(source, validator, _pre_balance, _amount, _) => {
+            Check::BondDecrease(source, validator, _pre_balance, _amount) => {
                 write!(f, "bond/{}/{}/decrease", source.name, validator)
             }
-            Check::AccountExist(source, _threshold, _sources, _) => {
+            Check::AccountExist(source, _threshold, _sources) => {
                 write!(f, "account-exist/{}", source.name)
             }
             Check::IsValidatorAccount(target) => {

--- a/workload/src/execute/batch.rs
+++ b/workload/src/execute/batch.rs
@@ -7,11 +7,11 @@ use super::utils::{self, execute_tx};
 pub async fn execute_tx_batch(
     sdk: &Sdk,
     txs: Vec<(Tx, SigningTxData)>,
-    settings: TaskSettings,
+    settings: &TaskSettings,
 ) -> Result<Option<u64>, StepError> {
-    let (mut tx, signing_datas, tx_args) = utils::merge_tx(sdk, txs, settings)
+    let (tx, signing_datas, tx_args) = utils::merge_tx(sdk, txs, settings)
         .await
         .map_err(|e| StepError::Build(e.to_string()))?;
 
-    execute_tx(sdk, &mut tx, signing_datas, &tx_args).await
+    execute_tx(sdk, tx, signing_datas, &tx_args).await
 }

--- a/workload/src/execute/bond.rs
+++ b/workload/src/execute/bond.rs
@@ -32,12 +32,12 @@ pub async fn build_tx_bond(
     let fee_payer = wallet
         .find_public_key(&settings.gas_payer.name)
         .map_err(|e| StepError::Wallet(e.to_string()))?;
-    let validator = Address::from_str(&validator).unwrap(); // safe
+    let validator = Address::from_str(validator).expect("ValidatorAddress should be converted");
 
     let mut bond_tx_builder = sdk
         .namada
         .new_bond(validator, token_amount)
-        .source(source_address.as_ref().clone());
+        .source(source_address.into_owned());
     bond_tx_builder = bond_tx_builder.gas_limit(GasLimit::from(settings.gas_limit));
     bond_tx_builder = bond_tx_builder.wrapper_fee_payer(fee_payer);
     let mut signing_keys = vec![];

--- a/workload/src/execute/change_metadata.rs
+++ b/workload/src/execute/change_metadata.rs
@@ -7,42 +7,49 @@ use namada_sdk::{
 
 use crate::{entities::Alias, sdk::namada::Sdk, steps::StepError, task::TaskSettings};
 
-use super::utils;
+use super::utils::execute_tx;
 
 #[allow(clippy::too_many_arguments)]
 pub async fn build_tx_change_metadata(
     sdk: &Sdk,
-    source: Alias,
-    website: String,
-    email: String,
-    discord: String,
-    description: String,
-    avatar: String,
-    settings: TaskSettings,
+    source: &Alias,
+    website: &str,
+    email: &str,
+    discord: &str,
+    description: &str,
+    avatar: &str,
+    settings: &TaskSettings,
 ) -> Result<(Tx, SigningTxData, args::Tx), StepError> {
     let wallet = sdk.namada.wallet.read().await;
-    let source_address = wallet.find_address(source.name).unwrap().into_owned();
-    let fee_payer = wallet.find_public_key(&settings.gas_payer.name).unwrap();
+    let source_address = wallet
+        .find_address(&source.name)
+        .ok_or_else(|| StepError::Wallet(format!("No source address: {}", source.name)))?;
+    let fee_payer = wallet
+        .find_public_key(&settings.gas_payer.name)
+        .map_err(|e| StepError::Wallet(e.to_string()))?;
 
     let mut change_metadata_tx_builder = sdk
         .namada
-        .new_change_metadata(source_address.clone())
-        .avatar(avatar)
-        .description(description)
-        .discord_handle(discord)
-        .email(email)
-        .website(website);
+        .new_change_metadata(source_address.into_owned())
+        .avatar(avatar.to_string())
+        .description(description.to_string())
+        .discord_handle(discord.to_string())
+        .email(email.to_string())
+        .website(website.to_string());
 
     change_metadata_tx_builder =
         change_metadata_tx_builder.gas_limit(GasLimit::from(settings.gas_limit));
     change_metadata_tx_builder = change_metadata_tx_builder.wrapper_fee_payer(fee_payer);
 
     let mut signing_keys = vec![];
-    for signer in settings.signers {
-        let public_key = wallet.find_public_key(&signer.name).unwrap();
+    for signer in &settings.signers {
+        let public_key = wallet
+            .find_public_key(&signer.name)
+            .map_err(|e| StepError::Wallet(e.to_string()))?;
         signing_keys.push(public_key)
     }
-    change_metadata_tx_builder = change_metadata_tx_builder.signing_keys(signing_keys.clone());
+    change_metadata_tx_builder = change_metadata_tx_builder.signing_keys(signing_keys);
+    drop(wallet);
 
     let (change_metadata, signing_data) = change_metadata_tx_builder
         .build(&sdk.namada)
@@ -52,11 +59,28 @@ pub async fn build_tx_change_metadata(
     Ok((change_metadata, signing_data, change_metadata_tx_builder.tx))
 }
 
-pub async fn execute_tx_become_validator(
+#[allow(clippy::too_many_arguments)]
+pub async fn execute_tx_change_metadata(
     sdk: &Sdk,
-    tx: &mut Tx,
-    signing_data: SigningTxData,
-    tx_args: &args::Tx,
+    source: &Alias,
+    website: &str,
+    email: &str,
+    discord: &str,
+    description: &str,
+    avatar: &str,
+    settings: &TaskSettings,
 ) -> Result<Option<u64>, StepError> {
-    utils::execute_tx(sdk, tx, vec![signing_data], tx_args).await
+    let (change_metadata_tx, signing_data, tx_args) = build_tx_change_metadata(
+        sdk,
+        source,
+        website,
+        email,
+        discord,
+        description,
+        avatar,
+        settings,
+    )
+    .await?;
+
+    execute_tx(sdk, change_metadata_tx, vec![signing_data], &tx_args).await
 }

--- a/workload/src/execute/claim_rewards.rs
+++ b/workload/src/execute/claim_rewards.rs
@@ -28,12 +28,14 @@ pub async fn build_tx_claim_rewards(
     let source_address = wallet
         .find_address(&source.name)
         .ok_or_else(|| StepError::Wallet(format!("No source address: {}", source.name)))?;
-    let fee_payer = wallet.find_public_key(&settings.gas_payer.name).unwrap();
+    let fee_payer = wallet
+        .find_public_key(&settings.gas_payer.name)
+        .map_err(|e| StepError::Wallet(e.to_string()))?;
     let from_validator =
-        Address::from_str(&from_validator).expect("ValidatorAddress should be converted");
+        Address::from_str(from_validator).expect("ValidatorAddress should be converted");
 
     let mut claim_rewards_tx_builder = sdk.namada.new_claim_rewards(from_validator);
-    claim_rewards_tx_builder.source = Some(source_address.as_ref().clone());
+    claim_rewards_tx_builder.source = Some(source_address.into_owned());
     claim_rewards_tx_builder =
         claim_rewards_tx_builder.gas_limit(GasLimit::from(settings.gas_limit));
     claim_rewards_tx_builder = claim_rewards_tx_builder.wrapper_fee_payer(fee_payer);

--- a/workload/src/execute/deactivate_validator.rs
+++ b/workload/src/execute/deactivate_validator.rs
@@ -7,31 +7,37 @@ use namada_sdk::{
 
 use crate::{entities::Alias, sdk::namada::Sdk, steps::StepError, task::TaskSettings};
 
-use super::utils;
+use super::utils::execute_tx;
 
 pub async fn build_tx_deactivate_validator(
     sdk: &Sdk,
-    source: Alias,
-    settings: TaskSettings,
+    target: &Alias,
+    settings: &TaskSettings,
 ) -> Result<(Tx, SigningTxData, args::Tx), StepError> {
     let wallet = sdk.namada.wallet.read().await;
-    let source_address = wallet.find_address(source.name).unwrap().into_owned();
-    let fee_payer = wallet.find_public_key(&settings.gas_payer.name).unwrap();
+    let target_address = wallet
+        .find_address(&target.name)
+        .ok_or_else(|| StepError::Wallet(format!("No target address: {}", target.name)))?;
+    let fee_payer = wallet
+        .find_public_key(&settings.gas_payer.name)
+        .map_err(|e| StepError::Wallet(e.to_string()))?;
 
-    let mut deactivate_validator_builder_tx =
-        sdk.namada.new_deactivate_validator(source_address.clone());
+    let mut deactivate_validator_builder_tx = sdk
+        .namada
+        .new_deactivate_validator(target_address.into_owned());
 
     deactivate_validator_builder_tx =
         deactivate_validator_builder_tx.gas_limit(GasLimit::from(settings.gas_limit));
     deactivate_validator_builder_tx = deactivate_validator_builder_tx.wrapper_fee_payer(fee_payer);
 
     let mut signing_keys = vec![];
-    for signer in settings.signers {
-        let public_key = wallet.find_public_key(&signer.name).unwrap();
+    for signer in &settings.signers {
+        let public_key = wallet
+            .find_public_key(&signer.name)
+            .map_err(|e| StepError::Wallet(e.to_string()))?;
         signing_keys.push(public_key)
     }
-    deactivate_validator_builder_tx =
-        deactivate_validator_builder_tx.signing_keys(signing_keys.clone());
+    deactivate_validator_builder_tx = deactivate_validator_builder_tx.signing_keys(signing_keys);
 
     let (deactivate_validator, signing_data) = deactivate_validator_builder_tx
         .build(&sdk.namada)
@@ -47,9 +53,11 @@ pub async fn build_tx_deactivate_validator(
 
 pub async fn execute_tx_deactivate_validator(
     sdk: &Sdk,
-    tx: &mut Tx,
-    signing_data: SigningTxData,
-    tx_args: &args::Tx,
+    target: &Alias,
+    settings: &TaskSettings,
 ) -> Result<Option<u64>, StepError> {
-    utils::execute_tx(sdk, tx, vec![signing_data], tx_args).await
+    let (deactivate_tx, signing_data, tx_args) =
+        build_tx_deactivate_validator(sdk, target, settings).await?;
+
+    execute_tx(sdk, deactivate_tx, vec![signing_data], &tx_args).await
 }

--- a/workload/src/execute/default_proposal.rs
+++ b/workload/src/execute/default_proposal.rs
@@ -10,25 +10,29 @@ use namada_sdk::{
 
 use crate::{entities::Alias, sdk::namada::Sdk, steps::StepError, task::TaskSettings};
 
-use super::utils;
+use super::utils::execute_tx;
 
 #[allow(clippy::too_many_arguments)]
 pub async fn build_tx_default_proposal(
     sdk: &Sdk,
-    source: Alias,
+    source: &Alias,
     start_epoch: u64,
     end_epoch: u64,
     grace_epoch: u64,
-    settings: TaskSettings,
+    settings: &TaskSettings,
 ) -> Result<(Tx, SigningTxData, args::Tx), StepError> {
     let wallet = sdk.namada.wallet.read().await;
-    let source_address = wallet.find_address(source.name).unwrap().into_owned();
-    let fee_payer = wallet.find_public_key(&settings.gas_payer.name).unwrap();
+    let source_address = wallet
+        .find_address(&source.name)
+        .ok_or_else(|| StepError::Wallet(format!("No source address: {}", source.name)))?;
+    let fee_payer = wallet
+        .find_public_key(&settings.gas_payer.name)
+        .map_err(|e| StepError::Wallet(e.to_string()))?;
 
     let default_proposal = DefaultProposal {
         proposal: OnChainProposal {
             content: BTreeMap::from_iter([("workload".to_string(), "tester".to_string())]),
-            author: source_address.clone(),
+            author: source_address.into_owned(),
             voting_start_epoch: start_epoch.into(),
             voting_end_epoch: end_epoch.into(),
             activation_epoch: grace_epoch.into(),
@@ -39,7 +43,8 @@ pub async fn build_tx_default_proposal(
             None
         },
     };
-    let proposal_json = serde_json::to_string(&default_proposal).unwrap();
+    let proposal_json =
+        serde_json::to_string(&default_proposal).expect("Encoding proposal shouldn't fail");
 
     let mut default_proposal_tx_builder = sdk.namada.new_init_proposal(proposal_json.into_bytes());
 
@@ -48,11 +53,13 @@ pub async fn build_tx_default_proposal(
     default_proposal_tx_builder = default_proposal_tx_builder.wrapper_fee_payer(fee_payer);
 
     let mut signing_keys = vec![];
-    for signer in settings.signers {
-        let public_key = wallet.find_public_key(&signer.name).unwrap();
+    for signer in &settings.signers {
+        let public_key = wallet
+            .find_public_key(&signer.name)
+            .map_err(|e| StepError::Wallet(e.to_string()))?;
         signing_keys.push(public_key)
     }
-    default_proposal_tx_builder = default_proposal_tx_builder.signing_keys(signing_keys.clone());
+    default_proposal_tx_builder = default_proposal_tx_builder.signing_keys(signing_keys);
     drop(wallet);
 
     let (default_proposal, signing_data) = default_proposal_tx_builder
@@ -69,9 +76,15 @@ pub async fn build_tx_default_proposal(
 
 pub async fn execute_tx_default_proposal(
     sdk: &Sdk,
-    tx: &mut Tx,
-    signing_data: SigningTxData,
-    tx_args: &args::Tx,
+    source: &Alias,
+    start_epoch: u64,
+    end_epoch: u64,
+    grace_epoch: u64,
+    settings: &TaskSettings,
 ) -> Result<Option<u64>, StepError> {
-    utils::execute_tx(sdk, tx, vec![signing_data], tx_args).await
+    let (default_proposal_tx, signing_data, tx_args) =
+        build_tx_default_proposal(sdk, source, start_epoch, end_epoch, grace_epoch, settings)
+            .await?;
+
+    execute_tx(sdk, default_proposal_tx, vec![signing_data], &tx_args).await
 }

--- a/workload/src/execute/faucet_transfer.rs
+++ b/workload/src/execute/faucet_transfer.rs
@@ -1,23 +1,22 @@
 use namada_sdk::{
-    args::{InputAmount, TxBuilder, TxTransparentTransferData},
-    rpc::TxResponse,
-    signing::default_sign,
+    args::{self, InputAmount, TxBuilder, TxTransparentTransferData},
+    signing::SigningTxData,
     token::{self, DenominatedAmount},
-    tx::{data::GasLimit, ProcessTxResponse},
+    tx::{data::GasLimit, Tx},
     Namada,
 };
 
 use crate::{entities::Alias, sdk::namada::Sdk, steps::StepError, task::TaskSettings};
 
-use super::utils;
+use super::utils::execute_tx;
 
-pub async fn execute_faucet_transfer(
+pub async fn build_faucet_transfer(
     sdk: &Sdk,
-    target: Alias,
+    target: &Alias,
     amount: u64,
-    settings: TaskSettings,
-) -> Result<Option<u64>, StepError> {
-    let wallet = sdk.namada.wallet.write().await;
+    settings: &TaskSettings,
+) -> Result<(Tx, SigningTxData, args::Tx), StepError> {
+    let wallet = sdk.namada.wallet.read().await;
 
     let faucet_alias = Alias::faucet();
     let native_token_alias = Alias::nam();
@@ -27,7 +26,7 @@ pub async fn execute_faucet_transfer(
         .unwrap()
         .as_ref()
         .clone();
-    let target_address = wallet.find_address(target.name).unwrap().as_ref().clone();
+    let target_address = wallet.find_address(&target.name).unwrap().as_ref().clone();
     let token_address = wallet
         .find_address(native_token_alias.name)
         .unwrap()
@@ -49,49 +48,29 @@ pub async fn execute_faucet_transfer(
     transfer_tx_builder = transfer_tx_builder.wrapper_fee_payer(fee_payer);
 
     let mut signing_keys = vec![];
-    for signer in settings.signers {
+    for signer in &settings.signers {
         let public_key = wallet.find_public_key(&signer.name).unwrap();
         signing_keys.push(public_key)
     }
-    transfer_tx_builder = transfer_tx_builder.signing_keys(signing_keys.clone());
+    transfer_tx_builder = transfer_tx_builder.signing_keys(signing_keys);
     drop(wallet);
 
-    let (mut transfer_tx, signing_data) = transfer_tx_builder
+    let (transfer_tx, signing_data) = transfer_tx_builder
         .build(&sdk.namada)
         .await
         .map_err(|e| StepError::Build(e.to_string()))?;
 
-    sdk.namada
-        .sign(
-            &mut transfer_tx,
-            &transfer_tx_builder.tx,
-            signing_data,
-            default_sign,
-            (),
-        )
-        .await
-        .expect("unable to sign tx");
+    Ok((transfer_tx, signing_data, transfer_tx_builder.tx))
+}
 
-    let tx = sdk
-        .namada
-        .submit(transfer_tx.clone(), &transfer_tx_builder.tx)
-        .await;
+pub async fn execute_faucet_transfer(
+    sdk: &Sdk,
+    target: &Alias,
+    amount: u64,
+    settings: &TaskSettings,
+) -> Result<Option<u64>, StepError> {
+    let (transfer_tx, signing_data, tx_args) =
+        build_faucet_transfer(sdk, target, amount, settings).await?;
 
-    let execution_height = if let Ok(ProcessTxResponse::Applied(TxResponse { height, .. })) = &tx {
-        Some(height.0)
-    } else {
-        None
-    };
-
-    if utils::is_tx_rejected(&transfer_tx, &tx) {
-        match tx {
-            Ok(tx) => {
-                let errors = utils::get_tx_errors(&transfer_tx, &tx).unwrap_or_default();
-                return Err(StepError::Execution(errors));
-            }
-            Err(e) => return Err(StepError::Broadcast(e.to_string())),
-        }
-    }
-
-    Ok(execution_height)
+    execute_tx(sdk, transfer_tx, vec![signing_data], &tx_args).await
 }

--- a/workload/src/execute/init_account.rs
+++ b/workload/src/execute/init_account.rs
@@ -28,7 +28,9 @@ pub async fn build_tx_init_account(
         public_keys.push(source_pk);
     }
 
-    let fee_payer = wallet.find_public_key(&settings.gas_payer.name).unwrap();
+    let fee_payer = wallet
+        .find_public_key(&settings.gas_payer.name)
+        .map_err(|e| StepError::Wallet(e.to_string()))?;
 
     let mut init_account_builder = sdk
         .namada

--- a/workload/src/execute/new_wallet_keypair.rs
+++ b/workload/src/execute/new_wallet_keypair.rs
@@ -27,7 +27,12 @@ pub async fn execute_new_wallet_key_pair(
             None,
             &mut OsRng,
         )
-        .ok_or_else(|| StepError::Wallet(format!("Failed to generate keypair")))?;
+        .ok_or_else(|| {
+            StepError::Wallet(format!(
+                "Failed to generate keypair for {}",
+                source_alias.name
+            ))
+        })?;
 
     let spending_key_alias = format!("{}-spending-key", source_alias.name);
     let (_alias, spending_key) = wallet
@@ -38,7 +43,12 @@ pub async fn execute_new_wallet_key_pair(
             true,
             &mut OsRng,
         )
-        .ok_or_else(|| StepError::Wallet(format!("Failed to generate spending key")))?;
+        .ok_or_else(|| {
+            StepError::Wallet(format!(
+                "Failed to generate spending key for {}",
+                spending_key_alias
+            ))
+        })?;
 
     let viewing_key = zip32::ExtendedFullViewingKey::from(&spending_key.into())
         .fvk

--- a/workload/src/execute/new_wallet_keypair.rs
+++ b/workload/src/execute/new_wallet_keypair.rs
@@ -1,10 +1,8 @@
 use namada_sdk::{
-    io::Client,
     key::{common, SchemeType},
     masp::find_valid_diversifier,
     masp_primitives::zip32,
-    state::BlockHeight,
-    PaymentAddress,
+    rpc, PaymentAddress,
 };
 use rand::rngs::OsRng;
 
@@ -12,53 +10,35 @@ use crate::{entities::Alias, sdk::namada::Sdk, steps::StepError};
 
 pub async fn execute_new_wallet_key_pair(
     sdk: &Sdk,
-    source_alias: Alias,
+    source_alias: &Alias,
 ) -> Result<common::PublicKey, StepError> {
-    let client = sdk.namada.clone_client();
-    let current_height = BlockHeight::from(
-        client
-            .latest_block()
-            .await
-            .map_err(|e| StepError::Build(e.to_string()))?
-            .block
-            .last_commit
-            .unwrap()
-            .height
-            .value(),
-    );
+    let block = rpc::query_block(&sdk.namada.client)
+        .await
+        .map_err(|e| StepError::Rpc(e.to_string()))?
+        .ok_or_else(|| StepError::StateCheck("No block found".to_string()))?;
 
     let mut wallet = sdk.namada.wallet.write().await;
 
-    let keypair = wallet.gen_store_secret_key(
-        SchemeType::Ed25519,
-        Some(source_alias.name.clone()),
-        true,
-        None,
-        &mut OsRng,
-    );
+    let (_alias, sk) = wallet
+        .gen_store_secret_key(
+            SchemeType::Ed25519,
+            Some(source_alias.name.clone()),
+            true,
+            None,
+            &mut OsRng,
+        )
+        .ok_or_else(|| StepError::Wallet(format!("Failed to generate keypair")))?;
 
-    let (_alias, sk) = if let Some((alias, sk)) = keypair {
-        wallet.save().expect("unable to save wallet");
-        (alias, sk)
-    } else {
-        return Err(StepError::Wallet("Failed to save keypair".to_string()));
-    };
-
-    let spending_key_alias = format!("{}-spending-key", source_alias.name.clone());
-    let spending_key = wallet.gen_store_spending_key(
-        spending_key_alias.clone(),
-        Some(current_height),
-        None,
-        true,
-        &mut OsRng,
-    );
-
-    let (_, spending_key) = if let Some((alias, sk)) = spending_key {
-        wallet.save().expect("unable to save wallet");
-        (alias, sk)
-    } else {
-        return Err(StepError::Build("Can't save spending key".to_string()));
-    };
+    let spending_key_alias = format!("{}-spending-key", source_alias.name);
+    let (_alias, spending_key) = wallet
+        .gen_store_spending_key(
+            spending_key_alias.clone(),
+            Some(block.height),
+            None,
+            true,
+            &mut OsRng,
+        )
+        .ok_or_else(|| StepError::Wallet(format!("Failed to generate spending key")))?;
 
     let viewing_key = zip32::ExtendedFullViewingKey::from(&spending_key.into())
         .fvk
@@ -71,9 +51,10 @@ pub async fn execute_new_wallet_key_pair(
 
     let payment_address_alias = format!("{}-payment-address", source_alias.name);
     wallet.insert_payment_addr(payment_address_alias, payment_addr, true);
-    wallet.save().expect("unable to save wallet");
 
-    drop(wallet);
+    wallet
+        .save()
+        .map_err(|e| StepError::Wallet(format!("Failed to save the wallet: {e}")))?;
 
     Ok(sk.to_public())
 }

--- a/workload/src/execute/reactivate_validator.rs
+++ b/workload/src/execute/reactivate_validator.rs
@@ -7,31 +7,37 @@ use namada_sdk::{
 
 use crate::{entities::Alias, sdk::namada::Sdk, steps::StepError, task::TaskSettings};
 
-use super::utils;
+use super::utils::execute_tx;
 
 pub async fn build_tx_reactivate_validator(
     sdk: &Sdk,
-    source: Alias,
-    settings: TaskSettings,
+    target: &Alias,
+    settings: &TaskSettings,
 ) -> Result<(Tx, SigningTxData, args::Tx), StepError> {
     let wallet = sdk.namada.wallet.read().await;
-    let source_address = wallet.find_address(source.name).unwrap().into_owned();
-    let fee_payer = wallet.find_public_key(&settings.gas_payer.name).unwrap();
+    let target_address = wallet
+        .find_address(&target.name)
+        .ok_or_else(|| StepError::Wallet(format!("No target address: {}", target.name)))?;
+    let fee_payer = wallet
+        .find_public_key(&settings.gas_payer.name)
+        .map_err(|e| StepError::Wallet(e.to_string()))?;
 
-    let mut reactivate_validator_builder_tx =
-        sdk.namada.new_reactivate_validator(source_address.clone());
+    let mut reactivate_validator_builder_tx = sdk
+        .namada
+        .new_reactivate_validator(target_address.into_owned());
 
     reactivate_validator_builder_tx =
         reactivate_validator_builder_tx.gas_limit(GasLimit::from(settings.gas_limit));
     reactivate_validator_builder_tx = reactivate_validator_builder_tx.wrapper_fee_payer(fee_payer);
 
     let mut signing_keys = vec![];
-    for signer in settings.signers {
-        let public_key = wallet.find_public_key(&signer.name).unwrap();
+    for signer in &settings.signers {
+        let public_key = wallet
+            .find_public_key(&signer.name)
+            .map_err(|e| StepError::Wallet(e.to_string()))?;
         signing_keys.push(public_key)
     }
-    reactivate_validator_builder_tx =
-        reactivate_validator_builder_tx.signing_keys(signing_keys.clone());
+    reactivate_validator_builder_tx = reactivate_validator_builder_tx.signing_keys(signing_keys);
 
     let (reactivate_validator, signing_data) = reactivate_validator_builder_tx
         .build(&sdk.namada)
@@ -47,9 +53,11 @@ pub async fn build_tx_reactivate_validator(
 
 pub async fn execute_tx_reactivate_validator(
     sdk: &Sdk,
-    tx: &mut Tx,
-    signing_data: SigningTxData,
-    tx_args: &args::Tx,
+    target: &Alias,
+    settings: &TaskSettings,
 ) -> Result<Option<u64>, StepError> {
-    utils::execute_tx(sdk, tx, vec![signing_data], tx_args).await
+    let (reactivate_tx, signing_data, tx_args) =
+        build_tx_reactivate_validator(sdk, target, settings).await?;
+
+    execute_tx(sdk, reactivate_tx, vec![signing_data], &tx_args).await
 }

--- a/workload/src/execute/redelegate.rs
+++ b/workload/src/execute/redelegate.rs
@@ -9,37 +9,53 @@ use namada_sdk::{
     Namada,
 };
 
-use crate::{entities::Alias, sdk::namada::Sdk, steps::StepError, task::TaskSettings};
+use crate::{
+    entities::Alias,
+    sdk::namada::Sdk,
+    steps::StepError,
+    task::{Address as ValidatorAddress, TaskSettings},
+};
 
-use super::utils;
+use super::utils::execute_tx;
 
 pub async fn build_tx_redelegate(
     sdk: &Sdk,
-    source: Alias,
-    from_validator: String,
-    to_validator: String,
+    source: &Alias,
+    from_validator: &ValidatorAddress,
+    to_validator: &ValidatorAddress,
     amount: u64,
-    settings: TaskSettings,
+    settings: &TaskSettings,
 ) -> Result<(Tx, SigningTxData, args::Tx), StepError> {
-    let wallet = sdk.namada.wallet.write().await;
+    let wallet = sdk.namada.wallet.read().await;
 
-    let source_address = wallet.find_address(source.name).unwrap().as_ref().clone();
+    let source_address = wallet
+        .find_address(&source.name)
+        .ok_or_else(|| StepError::Wallet(format!("No source address: {}", source.name)))?;
     let token_amount = token::Amount::from_u64(amount);
-    let fee_payer = wallet.find_public_key(&settings.gas_payer.name).unwrap();
-    let from_validator = Address::from_str(&from_validator).unwrap(); // safe
-    let to_validator = Address::from_str(&to_validator).unwrap(); // safe
+    let fee_payer = wallet
+        .find_public_key(&settings.gas_payer.name)
+        .map_err(|e| StepError::Wallet(e.to_string()))?;
+    let from_validator =
+        Address::from_str(&from_validator).expect("ValidatorAddress should be converted");
+    let to_validator =
+        Address::from_str(&to_validator).expect("ValidatorAddress should be converted");
 
-    let mut redelegate_tx_builder =
-        sdk.namada
-            .new_redelegation(source_address, from_validator, to_validator, token_amount);
+    let mut redelegate_tx_builder = sdk.namada.new_redelegation(
+        source_address.as_ref().clone(),
+        from_validator,
+        to_validator,
+        token_amount,
+    );
     redelegate_tx_builder = redelegate_tx_builder.gas_limit(GasLimit::from(settings.gas_limit));
     redelegate_tx_builder = redelegate_tx_builder.wrapper_fee_payer(fee_payer);
     let mut signing_keys = vec![];
-    for signer in settings.signers {
-        let public_key = wallet.find_public_key(&signer.name).unwrap();
+    for signer in &settings.signers {
+        let public_key = wallet
+            .find_public_key(&signer.name)
+            .map_err(|e| StepError::Wallet(e.to_string()))?;
         signing_keys.push(public_key)
     }
-    redelegate_tx_builder = redelegate_tx_builder.signing_keys(signing_keys.clone());
+    redelegate_tx_builder = redelegate_tx_builder.signing_keys(signing_keys);
     drop(wallet);
 
     let (bond_tx, signing_data) = redelegate_tx_builder
@@ -52,9 +68,14 @@ pub async fn build_tx_redelegate(
 
 pub async fn execute_tx_redelegate(
     sdk: &Sdk,
-    tx: &mut Tx,
-    signing_data: SigningTxData,
-    tx_args: &args::Tx,
+    source: &Alias,
+    from_validator: &ValidatorAddress,
+    to_validator: &ValidatorAddress,
+    amount: u64,
+    settings: &TaskSettings,
 ) -> Result<Option<u64>, StepError> {
-    utils::execute_tx(sdk, tx, vec![signing_data], tx_args).await
+    let (bond_tx, signing_data, tx_args) =
+        build_tx_redelegate(sdk, source, from_validator, to_validator, amount, settings).await?;
+
+    execute_tx(sdk, bond_tx, vec![signing_data], &tx_args).await
 }

--- a/workload/src/execute/redelegate.rs
+++ b/workload/src/execute/redelegate.rs
@@ -36,12 +36,12 @@ pub async fn build_tx_redelegate(
         .find_public_key(&settings.gas_payer.name)
         .map_err(|e| StepError::Wallet(e.to_string()))?;
     let from_validator =
-        Address::from_str(&from_validator).expect("ValidatorAddress should be converted");
+        Address::from_str(from_validator).expect("ValidatorAddress should be converted");
     let to_validator =
-        Address::from_str(&to_validator).expect("ValidatorAddress should be converted");
+        Address::from_str(to_validator).expect("ValidatorAddress should be converted");
 
     let mut redelegate_tx_builder = sdk.namada.new_redelegation(
-        source_address.as_ref().clone(),
+        source_address.into_owned(),
         from_validator,
         to_validator,
         token_amount,

--- a/workload/src/execute/reveal_pk.rs
+++ b/workload/src/execute/reveal_pk.rs
@@ -1,65 +1,30 @@
-use namada_sdk::{
-    args::TxBuilder,
-    key::common,
-    rpc::TxResponse,
-    signing::default_sign,
-    tx::{data::GasLimit, ProcessTxResponse},
-    Namada,
-};
+use namada_sdk::{args::TxBuilder, key::common, tx::data::GasLimit, Namada};
 
 use crate::{constants::DEFAULT_GAS_LIMIT, sdk::namada::Sdk, steps::StepError};
 
-use super::utils;
+use super::utils::execute_tx;
 
 pub async fn execute_reveal_pk(
     sdk: &Sdk,
     public_key: common::PublicKey,
 ) -> Result<Option<u64>, StepError> {
-    let wallet = sdk.namada.wallet.write().await;
-    let fee_payer = wallet.find_public_key("faucet").unwrap();
+    let wallet = sdk.namada.wallet.read().await;
+    let fee_payer = wallet
+        .find_public_key("faucet")
+        .map_err(|e| StepError::Wallet(e.to_string()))?;
     drop(wallet);
 
     let reveal_pk_tx_builder = sdk
         .namada
         .new_reveal_pk(public_key.clone())
-        .signing_keys(vec![public_key.clone()])
+        .signing_keys(vec![public_key])
         .gas_limit(GasLimit::from(DEFAULT_GAS_LIMIT * 2))
         .wrapper_fee_payer(fee_payer);
 
-    let (mut reveal_tx, signing_data) = reveal_pk_tx_builder
+    let (reveal_tx, signing_data) = reveal_pk_tx_builder
         .build(&sdk.namada)
         .await
         .map_err(|e| StepError::Build(e.to_string()))?;
 
-    sdk.namada
-        .sign(
-            &mut reveal_tx,
-            &reveal_pk_tx_builder.tx,
-            signing_data,
-            default_sign,
-            (),
-        )
-        .await
-        .expect("unable to sign tx");
-
-    let tx = sdk
-        .namada
-        .submit(reveal_tx.clone(), &reveal_pk_tx_builder.tx)
-        .await;
-
-    if utils::is_tx_rejected(&reveal_tx, &tx) {
-        match tx {
-            Ok(tx) => {
-                let errors = utils::get_tx_errors(&reveal_tx, &tx).unwrap_or_default();
-                return Err(StepError::Execution(errors));
-            }
-            Err(e) => return Err(StepError::Broadcast(e.to_string())),
-        }
-    }
-
-    if let Ok(ProcessTxResponse::Applied(TxResponse { height, .. })) = &tx {
-        Ok(Some(height.0))
-    } else {
-        Ok(None)
-    }
+    execute_tx(sdk, reveal_tx, vec![signing_data], &reveal_pk_tx_builder.tx).await
 }

--- a/workload/src/execute/shielded.rs
+++ b/workload/src/execute/shielded.rs
@@ -12,36 +12,45 @@ use rand::rngs::OsRng;
 
 use crate::{entities::Alias, sdk::namada::Sdk, steps::StepError, task::TaskSettings};
 
-use super::utils;
+use super::utils::execute_tx;
 
 pub async fn build_tx_shielded_transfer(
     sdk: &Sdk,
-    source: Alias,
-    target: Alias,
+    source: &Alias,
+    target: &Alias,
     amount: u64,
-    settings: TaskSettings,
+    settings: &TaskSettings,
 ) -> Result<(Tx, SigningTxData, args::Tx), StepError> {
     let mut bparams = RngBuildParams::new(OsRng);
     let mut wallet = sdk.namada.wallet.write().await;
 
     let native_token_alias = Alias::nam();
 
-    let source_spending_key = wallet.find_spending_key(source.name, None).unwrap();
+    let source_spending_key = wallet
+        .find_spending_key(&source.name, None)
+        .map_err(|e| StepError::Wallet(e.to_string()))?;
     let tmp = masp_primitives::zip32::ExtendedSpendingKey::from(source_spending_key);
     let pseudo_spending_key_from_spending_key = PseudoExtendedKey::from(tmp);
-    let target_payment_address = *wallet.find_payment_addr(target.name).unwrap();
+    let target_payment_address = *wallet
+        .find_payment_addr(&target.name)
+        .ok_or_else(|| StepError::Wallet(format!("No payment address: {}", target.name)))?;
     let token = wallet
-        .find_address(native_token_alias.name)
-        .unwrap()
-        .as_ref()
-        .clone();
+        .find_address(&native_token_alias.name)
+        .ok_or_else(|| {
+            StepError::Wallet(format!(
+                "No native token address: {}",
+                native_token_alias.name
+            ))
+        })?;
     let token_amount = token::Amount::from_u64(amount);
     let amount = InputAmount::Unvalidated(token::DenominatedAmount::native(token_amount));
-    let fee_payer = wallet.find_public_key(&settings.gas_payer.name).unwrap();
+    let fee_payer = wallet
+        .find_public_key(&settings.gas_payer.name)
+        .map_err(|e| StepError::Wallet(e.to_string()))?;
     let tx_transfer_data = TxShieldedTransferData {
         source: pseudo_spending_key_from_spending_key,
         target: target_payment_address,
-        token,
+        token: token.as_ref().clone(),
         amount,
     };
 
@@ -52,11 +61,13 @@ pub async fn build_tx_shielded_transfer(
     transfer_tx_builder = transfer_tx_builder.gas_limit(GasLimit::from(settings.gas_limit));
     transfer_tx_builder = transfer_tx_builder.wrapper_fee_payer(fee_payer);
     let mut signing_keys = vec![];
-    for signer in settings.signers {
-        let public_key = wallet.find_public_key(&signer.name).unwrap();
+    for signer in &settings.signers {
+        let public_key = wallet
+            .find_public_key(&signer.name)
+            .map_err(|e| StepError::Wallet(e.to_string()))?;
         signing_keys.push(public_key)
     }
-    transfer_tx_builder = transfer_tx_builder.signing_keys(signing_keys.clone());
+    transfer_tx_builder = transfer_tx_builder.signing_keys(signing_keys);
     drop(wallet);
 
     let (transfer_tx, signing_data) = transfer_tx_builder
@@ -69,9 +80,13 @@ pub async fn build_tx_shielded_transfer(
 
 pub async fn execute_tx_shielded_transfer(
     sdk: &Sdk,
-    tx: &mut Tx,
-    signing_data: SigningTxData,
-    tx_args: &args::Tx,
+    source: &Alias,
+    target: &Alias,
+    amount: u64,
+    settings: &TaskSettings,
 ) -> Result<Option<u64>, StepError> {
-    utils::execute_tx(sdk, tx, vec![signing_data], tx_args).await
+    let (transfer_tx, signing_data, tx_args) =
+        build_tx_shielded_transfer(sdk, source, target, amount, settings).await?;
+
+    execute_tx(sdk, transfer_tx, vec![signing_data], &tx_args).await
 }

--- a/workload/src/execute/shielded.rs
+++ b/workload/src/execute/shielded.rs
@@ -50,7 +50,7 @@ pub async fn build_tx_shielded_transfer(
     let tx_transfer_data = TxShieldedTransferData {
         source: pseudo_spending_key_from_spending_key,
         target: target_payment_address,
-        token: token.as_ref().clone(),
+        token: token.into_owned(),
         amount,
     };
 

--- a/workload/src/execute/shielding.rs
+++ b/workload/src/execute/shielding.rs
@@ -10,34 +10,43 @@ use rand::rngs::OsRng;
 
 use crate::{entities::Alias, sdk::namada::Sdk, steps::StepError, task::TaskSettings};
 
-use super::utils;
+use super::utils::execute_tx;
 
 pub async fn build_tx_shielding(
     sdk: &Sdk,
-    source: Alias,
-    target: Alias,
+    source: &Alias,
+    target: &Alias,
     amount: u64,
-    settings: TaskSettings,
+    settings: &TaskSettings,
 ) -> Result<(Tx, SigningTxData, args::Tx), StepError> {
     let mut bparams = RngBuildParams::new(OsRng);
 
-    let wallet = sdk.namada.wallet.write().await;
+    let wallet = sdk.namada.wallet.read().await;
 
     let native_token_alias = Alias::nam();
 
-    let source_address = wallet.find_address(source.name).unwrap().as_ref().clone();
-    let target_payment_address = *wallet.find_payment_addr(target.name).unwrap();
+    let source_address = wallet
+        .find_address(&source.name)
+        .ok_or_else(|| StepError::Wallet(format!("No source address: {}", source.name)))?;
+    let target_payment_address = *wallet
+        .find_payment_addr(&target.name)
+        .ok_or_else(|| StepError::Wallet(format!("No payment address: {}", target.name)))?;
     let token_address = wallet
-        .find_address(native_token_alias.name)
-        .unwrap()
-        .as_ref()
-        .clone();
-    let fee_payer = wallet.find_public_key(&settings.gas_payer.name).unwrap();
+        .find_address(&native_token_alias.name)
+        .ok_or_else(|| {
+            StepError::Wallet(format!(
+                "No native token address: {}",
+                native_token_alias.name
+            ))
+        })?;
+    let fee_payer = wallet
+        .find_public_key(&settings.gas_payer.name)
+        .map_err(|e| StepError::Wallet(e.to_string()))?;
     let token_amount = token::Amount::from_u64(amount);
 
     let tx_transfer_data = TxShieldingTransferData {
-        source: source_address,
-        token: token_address,
+        source: source_address.as_ref().clone(),
+        token: token_address.as_ref().clone(),
         amount: InputAmount::Unvalidated(DenominatedAmount::native(token_amount)),
     };
 
@@ -47,11 +56,13 @@ pub async fn build_tx_shielding(
     transfer_tx_builder = transfer_tx_builder.gas_limit(GasLimit::from(settings.gas_limit));
     transfer_tx_builder = transfer_tx_builder.wrapper_fee_payer(fee_payer);
     let mut signing_keys = vec![];
-    for signer in settings.signers {
-        let public_key = wallet.find_public_key(&signer.name).unwrap();
+    for signer in &settings.signers {
+        let public_key = wallet
+            .find_public_key(&signer.name)
+            .map_err(|e| StepError::Wallet(e.to_string()))?;
         signing_keys.push(public_key)
     }
-    transfer_tx_builder = transfer_tx_builder.signing_keys(signing_keys.clone());
+    transfer_tx_builder = transfer_tx_builder.signing_keys(signing_keys);
     drop(wallet);
 
     let (transfer_tx, signing_data, _epoch) = transfer_tx_builder
@@ -64,9 +75,12 @@ pub async fn build_tx_shielding(
 
 pub async fn execute_tx_shielding(
     sdk: &Sdk,
-    tx: &mut Tx,
-    signing_data: SigningTxData,
-    tx_args: &args::Tx,
+    source: &Alias,
+    target: &Alias,
+    amount: u64,
+    settings: &TaskSettings,
 ) -> Result<Option<u64>, StepError> {
-    utils::execute_tx(sdk, tx, vec![signing_data], tx_args).await
+    let (transfer_tx, signing_data, tx_args) =
+        build_tx_shielding(sdk, source, target, amount, settings).await?;
+    execute_tx(sdk, transfer_tx, vec![signing_data], &tx_args).await
 }

--- a/workload/src/execute/shielding.rs
+++ b/workload/src/execute/shielding.rs
@@ -45,8 +45,8 @@ pub async fn build_tx_shielding(
     let token_amount = token::Amount::from_u64(amount);
 
     let tx_transfer_data = TxShieldingTransferData {
-        source: source_address.as_ref().clone(),
-        token: token_address.as_ref().clone(),
+        source: source_address.into_owned(),
+        token: token_address.into_owned(),
         amount: InputAmount::Unvalidated(DenominatedAmount::native(token_amount)),
     };
 

--- a/workload/src/execute/transparent_transfer.rs
+++ b/workload/src/execute/transparent_transfer.rs
@@ -41,9 +41,9 @@ pub async fn build_tx_transparent_transfer(
     let token_amount = token::Amount::from_u64(amount);
 
     let tx_transfer_data = TxTransparentTransferData {
-        source: source_address.as_ref().clone(),
-        target: target_address.as_ref().clone(),
-        token: token_address.as_ref().clone(),
+        source: source_address.into_owned(),
+        target: target_address.into_owned(),
+        token: token_address.into_owned(),
         amount: InputAmount::Unvalidated(DenominatedAmount::native(token_amount)),
     };
 

--- a/workload/src/execute/transparent_transfer.rs
+++ b/workload/src/execute/transparent_transfer.rs
@@ -8,33 +8,42 @@ use namada_sdk::{
 
 use crate::{entities::Alias, sdk::namada::Sdk, steps::StepError, task::TaskSettings};
 
-use super::utils;
+use super::utils::execute_tx;
 
 pub async fn build_tx_transparent_transfer(
     sdk: &Sdk,
-    source: Alias,
-    target: Alias,
+    source: &Alias,
+    target: &Alias,
     amount: u64,
-    settings: TaskSettings,
+    settings: &TaskSettings,
 ) -> Result<(Tx, SigningTxData, args::Tx), StepError> {
-    let wallet = sdk.namada.wallet.write().await;
+    let wallet = sdk.namada.wallet.read().await;
 
     let native_token_alias = Alias::nam();
 
-    let source_address = wallet.find_address(source.name).unwrap().as_ref().clone();
-    let target_address = wallet.find_address(target.name).unwrap().as_ref().clone();
+    let source_address = wallet
+        .find_address(&source.name)
+        .ok_or_else(|| StepError::Wallet(format!("No source address: {}", source.name)))?;
+    let target_address = wallet
+        .find_address(&target.name)
+        .ok_or_else(|| StepError::Wallet(format!("No target address: {}", target.name)))?;
     let token_address = wallet
-        .find_address(native_token_alias.name)
-        .unwrap()
-        .as_ref()
-        .clone();
-    let fee_payer = wallet.find_public_key(&settings.gas_payer.name).unwrap();
+        .find_address(&native_token_alias.name)
+        .ok_or_else(|| {
+            StepError::Wallet(format!(
+                "No native token address: {}",
+                native_token_alias.name
+            ))
+        })?;
+    let fee_payer = wallet
+        .find_public_key(&settings.gas_payer.name)
+        .map_err(|e| StepError::Wallet(e.to_string()))?;
     let token_amount = token::Amount::from_u64(amount);
 
     let tx_transfer_data = TxTransparentTransferData {
-        source: source_address.clone(),
-        target: target_address.clone(),
-        token: token_address,
+        source: source_address.as_ref().clone(),
+        target: target_address.as_ref().clone(),
+        token: token_address.as_ref().clone(),
         amount: InputAmount::Unvalidated(DenominatedAmount::native(token_amount)),
     };
 
@@ -42,11 +51,13 @@ pub async fn build_tx_transparent_transfer(
     transfer_tx_builder = transfer_tx_builder.gas_limit(GasLimit::from(settings.gas_limit));
     transfer_tx_builder = transfer_tx_builder.wrapper_fee_payer(fee_payer);
     let mut signing_keys = vec![];
-    for signer in settings.signers {
-        let public_key = wallet.find_public_key(&signer.name).unwrap();
+    for signer in &settings.signers {
+        let public_key = wallet
+            .find_public_key(&signer.name)
+            .map_err(|e| StepError::Wallet(e.to_string()))?;
         signing_keys.push(public_key)
     }
-    transfer_tx_builder = transfer_tx_builder.signing_keys(signing_keys.clone());
+    transfer_tx_builder = transfer_tx_builder.signing_keys(signing_keys);
     drop(wallet);
 
     let (transfer_tx, signing_data) = transfer_tx_builder
@@ -59,9 +70,13 @@ pub async fn build_tx_transparent_transfer(
 
 pub async fn execute_tx_transparent_transfer(
     sdk: &Sdk,
-    tx: &mut Tx,
-    signing_data: SigningTxData,
-    tx_args: &args::Tx,
+    source: &Alias,
+    target: &Alias,
+    amount: u64,
+    settings: &TaskSettings,
 ) -> Result<Option<u64>, StepError> {
-    utils::execute_tx(sdk, tx, vec![signing_data], tx_args).await
+    let (transfer_tx, signing_data, tx_args) =
+        build_tx_transparent_transfer(sdk, source, target, amount, settings).await?;
+
+    execute_tx(sdk, transfer_tx, vec![signing_data], &tx_args).await
 }

--- a/workload/src/execute/unbond.rs
+++ b/workload/src/execute/unbond.rs
@@ -9,51 +9,64 @@ use namada_sdk::{
     Namada,
 };
 
-use crate::{entities::Alias, sdk::namada::Sdk, steps::StepError, task::TaskSettings};
+use crate::{
+    entities::Alias,
+    sdk::namada::Sdk,
+    steps::StepError,
+    task::{Address as ValidatorAddress, TaskSettings},
+};
 
-use super::utils;
+use super::utils::execute_tx;
 
 pub async fn build_tx_unbond(
     sdk: &Sdk,
-    source: Alias,
-    validator: String,
+    source: &Alias,
+    validator: &ValidatorAddress,
     amount: u64,
-    settings: TaskSettings,
+    settings: &TaskSettings,
 ) -> Result<(Tx, SigningTxData, args::Tx), StepError> {
-    let wallet = sdk.namada.wallet.write().await;
+    let wallet = sdk.namada.wallet.read().await;
 
-    let source_address = wallet.find_address(source.name).unwrap().as_ref().clone();
+    let source_address = wallet
+        .find_address(&source.name)
+        .ok_or_else(|| StepError::Wallet(format!("No source address: {}", source.name)))?;
     let token_amount = token::Amount::from_u64(amount);
-    let fee_payer = wallet.find_public_key(&settings.gas_payer.name).unwrap();
+    let fee_payer = wallet
+        .find_public_key(&settings.gas_payer.name)
+        .map_err(|e| StepError::Wallet(e.to_string()))?;
     let validator = Address::from_str(&validator).unwrap(); // safe
 
     let mut unbond_tx_builder = sdk
         .namada
         .new_unbond(validator, token_amount)
-        .source(source_address);
+        .source(source_address.as_ref().clone());
     unbond_tx_builder = unbond_tx_builder.gas_limit(GasLimit::from(settings.gas_limit));
     unbond_tx_builder = unbond_tx_builder.wrapper_fee_payer(fee_payer);
     let mut signing_keys = vec![];
-    for signer in settings.signers {
+    for signer in &settings.signers {
         let public_key = wallet.find_public_key(&signer.name).unwrap();
         signing_keys.push(public_key)
     }
-    unbond_tx_builder = unbond_tx_builder.signing_keys(signing_keys.clone());
+    unbond_tx_builder = unbond_tx_builder.signing_keys(signing_keys);
     drop(wallet);
 
-    let (bond_tx, signing_data, _epoch) = unbond_tx_builder
+    let (unbond_tx, signing_data, _epoch) = unbond_tx_builder
         .build(&sdk.namada)
         .await
         .map_err(|e| StepError::Build(e.to_string()))?;
 
-    Ok((bond_tx, signing_data, unbond_tx_builder.tx))
+    Ok((unbond_tx, signing_data, unbond_tx_builder.tx))
 }
 
 pub async fn execute_tx_unbond(
     sdk: &Sdk,
-    tx: &mut Tx,
-    signing_data: SigningTxData,
-    tx_args: &args::Tx,
+    source: &Alias,
+    validator: &ValidatorAddress,
+    amount: u64,
+    settings: &TaskSettings,
 ) -> Result<Option<u64>, StepError> {
-    utils::execute_tx(sdk, tx, vec![signing_data], tx_args).await
+    let (unbond_tx, signing_data, tx_args) =
+        build_tx_unbond(sdk, source, validator, amount, settings).await?;
+
+    execute_tx(sdk, unbond_tx, vec![signing_data], &tx_args).await
 }

--- a/workload/src/execute/unbond.rs
+++ b/workload/src/execute/unbond.rs
@@ -34,17 +34,19 @@ pub async fn build_tx_unbond(
     let fee_payer = wallet
         .find_public_key(&settings.gas_payer.name)
         .map_err(|e| StepError::Wallet(e.to_string()))?;
-    let validator = Address::from_str(&validator).unwrap(); // safe
+    let validator = Address::from_str(validator).expect("ValidatorAddress should be converted");
 
     let mut unbond_tx_builder = sdk
         .namada
         .new_unbond(validator, token_amount)
-        .source(source_address.as_ref().clone());
+        .source(source_address.into_owned());
     unbond_tx_builder = unbond_tx_builder.gas_limit(GasLimit::from(settings.gas_limit));
     unbond_tx_builder = unbond_tx_builder.wrapper_fee_payer(fee_payer);
     let mut signing_keys = vec![];
     for signer in &settings.signers {
-        let public_key = wallet.find_public_key(&signer.name).unwrap();
+        let public_key = wallet
+            .find_public_key(&signer.name)
+            .map_err(|e| StepError::Wallet(e.to_string()))?;
         signing_keys.push(public_key)
     }
     unbond_tx_builder = unbond_tx_builder.signing_keys(signing_keys);

--- a/workload/src/execute/unshielding.rs
+++ b/workload/src/execute/unshielding.rs
@@ -51,7 +51,7 @@ pub async fn build_tx_unshielding(
 
     let tx_transfer_data = TxUnshieldingTransferData {
         target: target_address.into_owned(),
-        token: token.as_ref().clone(),
+        token: token.into_owned(),
         amount,
     };
 

--- a/workload/src/execute/unshielding.rs
+++ b/workload/src/execute/unshielding.rs
@@ -12,38 +12,46 @@ use rand::rngs::OsRng;
 
 use crate::{entities::Alias, sdk::namada::Sdk, steps::StepError, task::TaskSettings};
 
-use super::utils;
+use super::utils::execute_tx;
 
 pub async fn build_tx_unshielding(
     sdk: &Sdk,
-    source: Alias,
-    target: Alias,
+    source: &Alias,
+    target: &Alias,
     amount: u64,
-    settings: TaskSettings,
+    settings: &TaskSettings,
 ) -> Result<(Tx, SigningTxData, args::Tx), StepError> {
     let mut bparams = RngBuildParams::new(OsRng);
 
     let mut wallet = sdk.namada.wallet.write().await;
 
+    let source_spending_key = wallet
+        .find_spending_key(&source.name, None)
+        .map_err(|e| StepError::Wallet(e.to_string()))?;
+    let tmp = masp_primitives::zip32::ExtendedSpendingKey::from(source_spending_key);
+    let pseudo_spending_key_from_spending_key = PseudoExtendedKey::from(tmp);
+    let target_address = wallet
+        .find_address(&target.name)
+        .ok_or_else(|| StepError::Wallet(format!("No target address: {}", target.name)))?;
+
     let native_token_alias = Alias::nam();
     let token = wallet
-        .find_address(native_token_alias.name)
-        .unwrap()
-        .as_ref()
-        .clone();
-    let fee_payer = wallet.find_public_key(&settings.gas_payer.name).unwrap();
+        .find_address(&native_token_alias.name)
+        .ok_or_else(|| {
+            StepError::Wallet(format!(
+                "No native token address: {}",
+                native_token_alias.name
+            ))
+        })?;
+    let fee_payer = wallet
+        .find_public_key(&settings.gas_payer.name)
+        .map_err(|e| StepError::Wallet(e.to_string()))?;
     let token_amount = token::Amount::from_u64(amount);
     let amount = InputAmount::Unvalidated(token::DenominatedAmount::native(token_amount));
 
-    let source_spending_key = wallet.find_spending_key(&source.name, None).unwrap();
-
-    let tmp = masp_primitives::zip32::ExtendedSpendingKey::from(source_spending_key);
-    let pseudo_spending_key_from_spending_key = PseudoExtendedKey::from(tmp);
-    let target_address = wallet.find_address(target.name).unwrap().clone();
-
     let tx_transfer_data = TxUnshieldingTransferData {
         target: target_address.into_owned(),
-        token,
+        token: token.as_ref().clone(),
         amount,
     };
 
@@ -57,11 +65,13 @@ pub async fn build_tx_unshielding(
     transfer_tx_builder = transfer_tx_builder.gas_limit(GasLimit::from(settings.gas_limit));
     transfer_tx_builder = transfer_tx_builder.wrapper_fee_payer(fee_payer);
     let mut signing_keys = vec![];
-    for signer in settings.signers {
-        let public_key = wallet.find_public_key(&signer.name).unwrap();
+    for signer in &settings.signers {
+        let public_key = wallet
+            .find_public_key(&signer.name)
+            .map_err(|e| StepError::Wallet(e.to_string()))?;
         signing_keys.push(public_key)
     }
-    transfer_tx_builder = transfer_tx_builder.signing_keys(signing_keys.clone());
+    transfer_tx_builder = transfer_tx_builder.signing_keys(signing_keys);
     drop(wallet);
 
     let (transfer_tx, signing_data) = transfer_tx_builder
@@ -69,17 +79,18 @@ pub async fn build_tx_unshielding(
         .await
         .map_err(|e| StepError::Build(e.to_string()))?;
 
-    // transfer_tx_builder.tx.signing_keys = signing_keys; //vec![gas_payer.clone()];
-    // transfer_tx_builder.tx.expiration = TxExpiration::NoExpiration;
-
     Ok((transfer_tx, signing_data, transfer_tx_builder.tx))
 }
 
 pub async fn execute_tx_unshielding(
     sdk: &Sdk,
-    tx: &mut Tx,
-    signing_data: SigningTxData,
-    tx_args: &args::Tx,
+    source: &Alias,
+    target: &Alias,
+    amount: u64,
+    settings: &TaskSettings,
 ) -> Result<Option<u64>, StepError> {
-    utils::execute_tx(sdk, tx, vec![signing_data], tx_args).await
+    let (transfer_tx, signing_data, tx_args) =
+        build_tx_unshielding(sdk, source, target, amount, settings).await?;
+
+    execute_tx(sdk, transfer_tx, vec![signing_data], &tx_args).await
 }

--- a/workload/src/execute/update_account.rs
+++ b/workload/src/execute/update_account.rs
@@ -9,39 +9,47 @@ use namada_sdk::{
 
 use crate::{entities::Alias, sdk::namada::Sdk, steps::StepError, task::TaskSettings};
 
-use super::utils;
+use super::utils::execute_tx;
 
 pub async fn build_tx_update_account(
     sdk: &Sdk,
-    target: Alias,
-    sources: BTreeSet<Alias>,
+    target: &Alias,
+    sources: &BTreeSet<Alias>,
     threshold: u64,
-    settings: TaskSettings,
+    settings: &TaskSettings,
 ) -> Result<(Tx, SigningTxData, args::Tx), StepError> {
-    let wallet = sdk.namada.wallet.write().await;
-    let target = wallet.find_address(target.name).unwrap().into_owned();
+    let wallet = sdk.namada.wallet.read().await;
+    let target = wallet
+        .find_address(&target.name)
+        .ok_or_else(|| StepError::Wallet(format!("No target address: {}", target.name)))?;
 
     let mut public_keys = vec![];
     for source in sources {
-        let source_pk = wallet.find_public_key(source.name).unwrap();
+        let source_pk = wallet
+            .find_public_key(&source.name)
+            .map_err(|e| StepError::Wallet(e.to_string()))?;
         public_keys.push(source_pk);
     }
 
-    let fee_payer = wallet.find_public_key(&settings.gas_payer.name).unwrap();
+    let fee_payer = wallet
+        .find_public_key(&settings.gas_payer.name)
+        .map_err(|e| StepError::Wallet(e.to_string()))?;
 
     let mut update_account_builder =
         sdk.namada
-            .new_update_account(target, public_keys, threshold as u8);
+            .new_update_account(target.into_owned(), public_keys, threshold as u8);
 
     update_account_builder = update_account_builder.gas_limit(GasLimit::from(settings.gas_limit));
     update_account_builder = update_account_builder.wrapper_fee_payer(fee_payer);
 
     let mut signing_keys = vec![];
-    for signer in settings.signers {
-        let public_key = wallet.find_public_key(&signer.name).unwrap();
+    for signer in &settings.signers {
+        let public_key = wallet
+            .find_public_key(&signer.name)
+            .map_err(|e| StepError::Wallet(e.to_string()))?;
         signing_keys.push(public_key)
     }
-    update_account_builder = update_account_builder.signing_keys(signing_keys.clone());
+    update_account_builder = update_account_builder.signing_keys(signing_keys);
     drop(wallet);
 
     let (update_account, signing_data) = update_account_builder
@@ -54,9 +62,13 @@ pub async fn build_tx_update_account(
 
 pub async fn execute_tx_update_account(
     sdk: &Sdk,
-    tx: &mut Tx,
-    signing_data: SigningTxData,
-    tx_args: &args::Tx,
+    target: &Alias,
+    sources: &BTreeSet<Alias>,
+    threshold: u64,
+    settings: &TaskSettings,
 ) -> Result<Option<u64>, StepError> {
-    utils::execute_tx(sdk, tx, vec![signing_data], tx_args).await
+    let (update_account_tx, signing_data, tx_args) =
+        build_tx_update_account(sdk, target, sources, threshold, settings).await?;
+
+    execute_tx(sdk, update_account_tx, vec![signing_data], &tx_args).await
 }

--- a/workload/src/execute/utils.rs
+++ b/workload/src/execute/utils.rs
@@ -2,12 +2,13 @@ use std::{path::PathBuf, str::FromStr};
 
 use namada_sdk::{
     args::{self, DeviceTransport, TxBuilder},
+    hash::Hash,
     rpc::TxResponse,
     signing::{default_sign, SigningTxData},
     tx::{
         self,
         data::{GasLimit, TxType},
-        either, ProcessTxResponse, Tx, TX_REVEAL_PK,
+        either, ProcessTxResponse, Tx, TxCommitments, TX_REVEAL_PK,
     },
     Namada,
 };
@@ -17,12 +18,11 @@ use crate::{
     task::TaskSettings,
 };
 
-pub(crate) fn is_tx_rejected(
-    tx: &Tx,
+fn is_tx_rejected(
+    cmt: &TxCommitments,
+    wrapper_hash: Option<Hash>,
     tx_response: &Result<ProcessTxResponse, namada_sdk::error::Error>,
 ) -> bool {
-    let cmt = tx.first_commitments().unwrap().to_owned();
-    let wrapper_hash = tx.wrapper_hash();
     match tx_response {
         Ok(tx_result) => tx_result
             .is_applied_and_valid(wrapper_hash.as_ref(), &cmt)
@@ -31,28 +31,28 @@ pub(crate) fn is_tx_rejected(
     }
 }
 
-pub(crate) fn get_tx_errors(tx: &Tx, tx_response: &ProcessTxResponse) -> Option<String> {
-    let cmt = tx.first_commitments().unwrap().to_owned();
-    let wrapper_hash = tx.wrapper_hash();
-    match tx_response {
-        ProcessTxResponse::Applied(result) => match &result.batch {
-            Some(batch) => {
-                tracing::info!("batch result: {:#?}", batch);
-                match batch.get_inner_tx_result(wrapper_hash.as_ref(), either::Right(&cmt)) {
-                    Some(Ok(res)) => {
-                        let errors = res.vps_result.errors.clone();
-                        let _status_flag = res.vps_result.status_flags;
-                        let _rejected_vps = res.vps_result.rejected_vps.clone();
-                        Some(serde_json::to_string(&errors).unwrap())
-                    }
-                    Some(Err(e)) => Some(e.to_string()),
-                    _ => None,
-                }
-            }
-            None => None,
-        },
-        _ => None,
+fn get_tx_errors(
+    cmt: &TxCommitments,
+    wrapper_hash: Option<Hash>,
+    tx_response: &ProcessTxResponse,
+) -> Option<String> {
+    if let ProcessTxResponse::Applied(result) = tx_response {
+        if let Some(batch) = &result.batch {
+            tracing::info!("batch result: {:#?}", batch);
+
+            return batch
+                .get_inner_tx_result(wrapper_hash.as_ref(), either::Right(&cmt))
+                .map(|res| {
+                    res.as_ref()
+                        .map(|res| {
+                            serde_json::to_string(&res.vps_result.errors)
+                                .expect("Encoding shouldn't fail")
+                        })
+                        .unwrap_or_else(|e| e.to_string())
+                });
+        }
     }
+    None
 }
 
 async fn default_tx_arg(sdk: &Sdk) -> args::Tx {
@@ -131,18 +131,25 @@ pub async fn merge_tx(
 
 pub(crate) async fn execute_tx(
     sdk: &Sdk,
-    tx: &mut Tx,
+    tx: Tx,
     signing_datas: Vec<SigningTxData>,
     tx_args: &args::Tx,
 ) -> Result<Option<u64>, StepError> {
-    do_sign_tx(sdk, tx, signing_datas, tx_args).await;
+    let mut tx = tx;
 
-    let tx_response = sdk.namada.submit(tx.clone(), tx_args).await;
+    do_sign_tx(sdk, &mut tx, signing_datas, tx_args).await;
 
-    if is_tx_rejected(tx, &tx_response) {
+    let cmt = tx
+        .first_commitments()
+        .expect("Commitments should exist")
+        .clone();
+    let wrapper_hash = tx.wrapper_hash();
+    let tx_response = sdk.namada.submit(tx, tx_args).await;
+
+    if is_tx_rejected(&cmt, wrapper_hash, &tx_response) {
         match tx_response {
             Ok(tx_response) => {
-                let errors = get_tx_errors(tx, &tx_response).unwrap_or_default();
+                let errors = get_tx_errors(&cmt, wrapper_hash, &tx_response).unwrap_or_default();
                 return Err(StepError::Execution(errors));
             }
             Err(e) => return Err(StepError::Broadcast(e.to_string())),

--- a/workload/src/main.rs
+++ b/workload/src/main.rs
@@ -37,13 +37,12 @@ enum Code {
 impl Code {
     fn code(&self) -> i32 {
         match self {
-            Code::Success(_) => 0,
-            Code::InvalidStep(_) => 0,
+            Code::Success(_) | Code::InvalidStep(_) => 0,
             Code::Fatal(_, _) => 1,
-            Code::ExecutionFailure(_, _) => 2,
-            Code::BroadcastFailure(_, _) => 3,
-            Code::OtherFailure(_, _) => 4,
-            Code::BuildFailure(_, _) => 5,
+            Code::BuildFailure(_, _) => 2,
+            Code::ExecutionFailure(_, _) => 3,
+            Code::BroadcastFailure(_, _) => 4,
+            Code::OtherFailure(_, _) => 5,
             Code::NoTask(_) => 6,
             Code::EmptyBatch(_) => 7,
         }
@@ -78,7 +77,9 @@ impl Code {
             Code::OtherFailure(step_type, reason) => {
                 tracing::warn!("Failure for {step_type} -> {reason}")
             }
-            Code::InvalidStep(step_type) => tracing::warn!("Invalid step for {step_type}, skipping..."),
+            Code::InvalidStep(step_type) => {
+                tracing::warn!("Invalid step for {step_type}, skipping...")
+            }
             Code::NoTask(step_type) => tracing::info!("No task for {step_type}, skipping..."),
             Code::BuildFailure(step_type, reason) => {
                 tracing::warn!("Build failure for {step_type} -> {reason}")
@@ -286,7 +287,7 @@ async fn inner_main() -> Code {
 
     let next_step = config.step_type;
     if !workload_executor.is_valid(&next_step, current_epoch, &state) {
-        tracing::warn!("Invalid step: {}, skipping... {:>?}", next_step, state);
+        tracing::warn!("Invalid step: {next_step} -> {state:>?}");
         return Code::InvalidStep(next_step);
     }
 

--- a/workload/src/state.rs
+++ b/workload/src/state.rs
@@ -314,7 +314,7 @@ impl State {
         let file = Self::lock_state_file(id)?;
 
         let data = fs::read_to_string(path).map_err(StateError::File)?;
-        if data.is_empty() {
+        if data.trim().is_empty() {
             return Err(StateError::EmptyFile);
         }
         let state = serde_json::from_str(&data).map_err(StateError::Serde)?;

--- a/workload/src/steps.rs
+++ b/workload/src/steps.rs
@@ -271,13 +271,7 @@ impl WorkloadExecutor {
         Ok(steps)
     }
 
-    pub async fn build_check(
-        &self,
-        sdk: &Sdk,
-        tasks: Vec<Task>,
-        state: &State,
-        no_check: bool,
-    ) -> Vec<Check> {
+    pub async fn build_check(&self, sdk: &Sdk, tasks: Vec<Task>, no_check: bool) -> Vec<Check> {
         if no_check {
             return vec![];
         }
@@ -288,14 +282,8 @@ impl WorkloadExecutor {
             let check = match task {
                 Task::NewWalletKeyPair(source) => vec![Check::RevealPk(source)],
                 Task::FaucetTransfer(target, amount, _) => {
-                    build_checks::faucet::faucet_build_check(
-                        sdk,
-                        target,
-                        amount,
-                        retry_config,
-                        state,
-                    )
-                    .await
+                    build_checks::faucet::faucet_build_check(sdk, target, amount, retry_config)
+                        .await
                 }
                 Task::TransparentTransfer(source, target, amount, _) => {
                     build_checks::transparent_transfer::transparent_transfer(
@@ -304,21 +292,12 @@ impl WorkloadExecutor {
                         target,
                         amount,
                         retry_config,
-                        state,
                     )
                     .await
                 }
                 Task::Bond(source, validator, amount, epoch, _) => {
-                    build_checks::bond::bond(
-                        sdk,
-                        source,
-                        validator,
-                        amount,
-                        epoch,
-                        retry_config,
-                        state,
-                    )
-                    .await
+                    build_checks::bond::bond(sdk, source, validator, amount, epoch, retry_config)
+                        .await
                 }
                 Task::InitAccount(alias, sources, threshold, _) => {
                     build_checks::init_account::init_account_build_checks(
@@ -327,7 +306,6 @@ impl WorkloadExecutor {
                         sources,
                         threshold,
                         retry_config,
-                        state,
                     )
                     .await
                 }
@@ -340,7 +318,6 @@ impl WorkloadExecutor {
                         amount,
                         epoch,
                         retry_config,
-                        state,
                     )
                     .await
                 }
@@ -352,7 +329,6 @@ impl WorkloadExecutor {
                         amount,
                         epoch,
                         retry_config,
-                        state,
                     )
                     .await
                 }
@@ -367,7 +343,6 @@ impl WorkloadExecutor {
                         amount,
                         false,
                         retry_config,
-                        state,
                     )
                     .await
                 }
@@ -379,7 +354,6 @@ impl WorkloadExecutor {
                         amount,
                         false,
                         retry_config,
-                        state,
                     )
                     .await
                 }
@@ -391,7 +365,6 @@ impl WorkloadExecutor {
                         amount,
                         false,
                         retry_config,
-                        state,
                     )
                     .await
                 }
@@ -411,7 +384,6 @@ impl WorkloadExecutor {
                         sources,
                         threshold,
                         retry_config,
-                        state,
                     )
                     .await
                 }
@@ -426,7 +398,6 @@ impl WorkloadExecutor {
                         sdk,
                         target,
                         retry_config,
-                        state,
                     )
                     .await
                 }
@@ -435,7 +406,6 @@ impl WorkloadExecutor {
                         sdk,
                         target,
                         retry_config,
-                        state,
                     )
                     .await
                 }
@@ -550,14 +520,12 @@ impl WorkloadExecutor {
                                     alias,
                                     pre_balance,
                                     amount.unsigned_abs(),
-                                    state.clone(),
                                 ));
                             } else {
                                 checks.push(Check::BalanceSource(
                                     alias,
                                     pre_balance,
                                     amount.unsigned_abs(),
-                                    state.clone(),
                                 ));
                             }
                         }
@@ -580,7 +548,6 @@ impl WorkloadExecutor {
                                     validator.to_owned(),
                                     pre_bond,
                                     amount.unsigned_abs(),
-                                    state.clone(),
                                 ));
                             } else {
                                 checks.push(Check::BondDecrease(
@@ -588,7 +555,6 @@ impl WorkloadExecutor {
                                     validator.to_owned(),
                                     pre_bond,
                                     amount.unsigned_abs(),
-                                    state.clone(),
                                 ));
                             }
                         }
@@ -608,14 +574,12 @@ impl WorkloadExecutor {
                                     alias,
                                     pre_balance,
                                     amount.unsigned_abs(),
-                                    state.clone(),
                                 ));
                             } else {
                                 checks.push(Check::BalanceShieldedSource(
                                     alias,
                                     pre_balance,
                                     amount.unsigned_abs(),
-                                    state.clone(),
                                 ));
                             }
                         }
@@ -713,7 +677,7 @@ impl WorkloadExecutor {
                         }
                     }
                 }
-                Check::BalanceTarget(target, pre_balance, amount, pre_state) => {
+                Check::BalanceTarget(target, pre_balance, amount) => {
                     let wallet = sdk.namada.wallet.read().await;
                     let native_token_address = wallet.find_address("nam").unwrap().into_owned();
                     let target_address = wallet.find_address(&target.name).unwrap().into_owned();
@@ -755,7 +719,6 @@ impl WorkloadExecutor {
                                     "pre_balance": pre_balance,
                                     "amount": amount,
                                     "post_balance": post_amount,
-                                    "pre_state": pre_state,
                                     "timeout": random_timeout,
                                     "execution_height": execution_height,
                                     "check_height": latest_block
@@ -770,7 +733,6 @@ impl WorkloadExecutor {
                                         "pre_balance": pre_balance,
                                         "amount": amount,
                                         "post_balance": post_amount,
-                                        "pre_state": pre_state,
                                         "timeout": random_timeout,
                                         "execution_height": execution_height,
                                         "check_height": latest_block
@@ -786,7 +748,7 @@ impl WorkloadExecutor {
                         }
                     }
                 }
-                Check::BalanceShieldedSource(target, pre_balance, amount, pre_state) => {
+                Check::BalanceShieldedSource(target, pre_balance, amount) => {
                     match build_checks::utils::get_shielded_balance(
                         sdk,
                         target.clone(),
@@ -814,7 +776,6 @@ impl WorkloadExecutor {
                                     "pre_balance": pre_balance,
                                     "amount": amount,
                                     "post_balance": post_balance,
-                                    "pre_state": pre_state,
                                     "timeout": random_timeout,
                                     "execution_height": execution_height,
                                     "check_height": latest_block
@@ -828,7 +789,6 @@ impl WorkloadExecutor {
                                         "pre_balance": pre_balance,
                                         "amount": amount,
                                         "post_balance": post_balance,
-                                        "pre_state": pre_state,
                                         "timeout": random_timeout,
                                         "execution_height": execution_height,
                                         "check_height": latest_block
@@ -844,7 +804,6 @@ impl WorkloadExecutor {
                                     "source_alias": target,
                                     "pre_balance": pre_balance,
                                     "amount": amount,
-                                    "pre_state": pre_state,
                                     "timeout": random_timeout,
                                     "execution_height": execution_height,
                                     "check_height": latest_block
@@ -862,7 +821,7 @@ impl WorkloadExecutor {
                         }
                     };
                 }
-                Check::BalanceShieldedTarget(target, pre_balance, amount, pre_state) => {
+                Check::BalanceShieldedTarget(target, pre_balance, amount) => {
                     match build_checks::utils::get_shielded_balance(
                         sdk,
                         target.clone(),
@@ -890,7 +849,6 @@ impl WorkloadExecutor {
                                     "pre_balance": pre_balance,
                                     "amount": amount,
                                     "post_balance": post_balance,
-                                    "pre_state": pre_state,
                                     "timeout": random_timeout,
                                     "execution_height": execution_height,
                                     "check_height": latest_block
@@ -904,7 +862,6 @@ impl WorkloadExecutor {
                                         "pre_balance": pre_balance,
                                         "amount": amount,
                                         "post_balance": post_balance,
-                                        "pre_state": pre_state,
                                         "timeout": random_timeout,
                                         "execution_height": execution_height,
                                         "check_height": latest_block
@@ -920,7 +877,6 @@ impl WorkloadExecutor {
                                     "target_alias": target,
                                     "pre_balance": pre_balance,
                                     "amount": amount,
-                                    "pre_state": pre_state,
                                     "timeout": random_timeout,
                                     "execution_height": execution_height,
                                     "check_height": latest_block
@@ -938,7 +894,7 @@ impl WorkloadExecutor {
                         }
                     };
                 }
-                Check::BalanceSource(target, pre_balance, amount, pre_state) => {
+                Check::BalanceSource(target, pre_balance, amount) => {
                     let wallet = sdk.namada.wallet.read().await;
                     let native_token_address = wallet.find_address("nam").unwrap().into_owned();
                     let target_address = wallet.find_address(&target.name).unwrap().into_owned();
@@ -980,7 +936,6 @@ impl WorkloadExecutor {
                                     "pre_balance": pre_balance,
                                     "amount": amount,
                                     "post_balance": post_amount,
-                                    "pre_state": pre_state,
                                     "timeout": random_timeout,
                                     "execution_height": execution_height,
                                     "check_height": latest_block
@@ -995,7 +950,6 @@ impl WorkloadExecutor {
                                         "pre_balance": pre_balance,
                                         "amount": amount,
                                         "post_balance": post_amount,
-                                        "pre_state": pre_state,
                                         "timeout": random_timeout,
                                         "execution_height": execution_height,
                                         "check_height": latest_block
@@ -1011,7 +965,7 @@ impl WorkloadExecutor {
                         }
                     }
                 }
-                Check::BondIncrease(target, validator, pre_bond, amount, pre_state) => {
+                Check::BondIncrease(target, validator, pre_bond, amount) => {
                     let wallet = sdk.namada.wallet.read().await;
                     let source_address = wallet.find_address(&target.name).unwrap().into_owned();
 
@@ -1069,7 +1023,6 @@ impl WorkloadExecutor {
                                     "pre_bond": pre_bond,
                                     "amount": amount,
                                     "post_bond": post_bond,
-                                    "pre_state": pre_state,
                                     "epoch": epoch,
                                     "timeout": random_timeout,
                                     "execution_height": execution_height,
@@ -1086,7 +1039,6 @@ impl WorkloadExecutor {
                                         "pre_bond": pre_bond,
                                         "amount": amount,
                                         "post_bond": post_bond,
-                                        "pre_state": pre_state,
                                         "epoch": epoch,
                                         "timeout": random_timeout,
                                         "execution_height": execution_height,
@@ -1101,7 +1053,7 @@ impl WorkloadExecutor {
                         }
                     }
                 }
-                Check::BondDecrease(target, validator, pre_bond, amount, pre_state) => {
+                Check::BondDecrease(target, validator, pre_bond, amount) => {
                     let wallet = sdk.namada.wallet.read().await;
                     let source_address = wallet.find_address(&target.name).unwrap().into_owned();
 
@@ -1159,7 +1111,6 @@ impl WorkloadExecutor {
                                     "pre_bond": pre_bond,
                                     "amount": amount,
                                     "post_bond": post_bond,
-                                    "pre_state": pre_state,
                                     "epoch": epoch,
                                     "timeout": random_timeout,
                                     "execution_height": execution_height,
@@ -1176,7 +1127,6 @@ impl WorkloadExecutor {
                                         "pre_bond": pre_bond,
                                         "amount": amount,
                                         "post_bond": post_bond,
-                                        "pre_state": pre_state,
                                         "epoch": epoch,
                                         "timeout": random_timeout,
                                         "execution_height": execution_height,
@@ -1191,7 +1141,7 @@ impl WorkloadExecutor {
                         }
                     }
                 }
-                Check::AccountExist(target, threshold, sources, pre_state) => {
+                Check::AccountExist(target, threshold, sources) => {
                     let wallet = sdk.namada.wallet.read().await;
                     let source_address = wallet.find_address(&target.name).unwrap().into_owned();
                     wallet.save().unwrap();
@@ -1220,7 +1170,6 @@ impl WorkloadExecutor {
                                     "account": account,
                                     "threshold": threshold,
                                     "sources": sources,
-                                    "pre_state": pre_state,
                                     "timeout": random_timeout,
                                     "execution_height": execution_height,
                                     "check_height": latest_block
@@ -1235,7 +1184,6 @@ impl WorkloadExecutor {
                                         "account": account,
                                         "threshold": threshold,
                                         "sources": sources,
-                                        "pre_state": pre_state,
                                         "timeout": random_timeout,
                                         "execution_height": execution_height,
                                         "check_height": latest_block
@@ -1256,7 +1204,6 @@ impl WorkloadExecutor {
                                     "account": "",
                                     "threshold": threshold,
                                     "sources": sources,
-                                    "pre_state": pre_state,
                                     "timeout": random_timeout,
                                     "execution_height": execution_height,
                                     "check_height": latest_block

--- a/workload/src/steps.rs
+++ b/workload/src/steps.rs
@@ -27,29 +27,6 @@ use crate::{
     check::Check,
     constants::{MIN_TRANSFER_BALANCE, PROPOSAL_DEPOSIT},
     entities::Alias,
-    execute::{
-        batch::execute_tx_batch,
-        become_validator::build_tx_become_validator,
-        bond::{build_tx_bond, execute_tx_bond},
-        change_consensus_keys::{build_tx_change_consensus_key, execute_tx_change_consensus_key},
-        change_metadata::build_tx_change_metadata,
-        claim_rewards::{build_tx_claim_rewards, execute_tx_claim_rewards},
-        deactivate_validator::{build_tx_deactivate_validator, execute_tx_deactivate_validator},
-        default_proposal::{build_tx_default_proposal, execute_tx_default_proposal},
-        faucet_transfer::execute_faucet_transfer,
-        init_account::{build_tx_init_account, execute_tx_init_account},
-        new_wallet_keypair::execute_new_wallet_key_pair,
-        reactivate_validator::{build_tx_reactivate_validator, execute_tx_reactivate_validator},
-        redelegate::{build_tx_redelegate, execute_tx_redelegate},
-        reveal_pk::execute_reveal_pk,
-        shielded::{build_tx_shielded_transfer, execute_tx_shielded_transfer},
-        shielding::{build_tx_shielding, execute_tx_shielding},
-        transparent_transfer::{build_tx_transparent_transfer, execute_tx_transparent_transfer},
-        unbond::{build_tx_unbond, execute_tx_unbond},
-        unshielding::{build_tx_unshielding, execute_tx_unshielding},
-        update_account::{build_tx_update_account, execute_tx_update_account},
-        vote::{build_tx_vote, execute_tx_vote},
-    },
     sdk::namada::Sdk,
     state::State,
     task::Task,
@@ -1336,176 +1313,13 @@ impl WorkloadExecutor {
     pub async fn execute(
         &self,
         sdk: &Sdk,
-        tasks: Vec<Task>,
+        tasks: &Vec<Task>,
     ) -> Result<Vec<ExecutionResult>, StepError> {
         let mut execution_results = vec![];
 
         for task in tasks {
             let now = Instant::now();
-            let execution_height = match task {
-                Task::NewWalletKeyPair(alias) => {
-                    let public_key = execute_new_wallet_key_pair(sdk, alias).await?;
-                    execute_reveal_pk(sdk, public_key).await?
-                }
-                Task::FaucetTransfer(target, amount, settings) => {
-                    execute_faucet_transfer(sdk, target, amount, settings).await?
-                }
-                Task::TransparentTransfer(source, target, amount, settings) => {
-                    let (mut tx, signing_data, tx_args) =
-                        build_tx_transparent_transfer(sdk, source, target, amount, settings)
-                            .await?;
-                    execute_tx_transparent_transfer(sdk, &mut tx, signing_data, &tx_args).await?
-                }
-                Task::Bond(source, validator, amount, _epoch, settings) => {
-                    let (mut tx, signing_data, tx_args) =
-                        build_tx_bond(sdk, source, validator, amount, settings).await?;
-                    execute_tx_bond(sdk, &mut tx, signing_data, &tx_args).await?
-                }
-                Task::InitAccount(source, sources, threshold, settings) => {
-                    let (mut tx, signing_data, tx_args) =
-                        build_tx_init_account(sdk, source, sources, threshold, settings).await?;
-                    execute_tx_init_account(sdk, &mut tx, signing_data, &tx_args).await?
-                }
-                Task::Redelegate(source, from, to, amount, _epoch, settings) => {
-                    let (mut tx, signing_data, tx_args) =
-                        build_tx_redelegate(sdk, source, from, to, amount, settings).await?;
-                    execute_tx_redelegate(sdk, &mut tx, signing_data, &tx_args).await?
-                }
-                Task::Unbond(source, validator, amount, _epoch, settings) => {
-                    let (mut tx, signing_data, tx_args) =
-                        build_tx_unbond(sdk, source, validator, amount, settings).await?;
-                    execute_tx_unbond(sdk, &mut tx, signing_data, &tx_args).await?
-                }
-                Task::ClaimRewards(source, validator, settings) => {
-                    let (mut tx, signing_data, tx_args) =
-                        build_tx_claim_rewards(sdk, source, validator, settings).await?;
-                    execute_tx_claim_rewards(sdk, &mut tx, signing_data, &tx_args).await?
-                }
-                Task::ShieldedTransfer(source, target, amount, settings) => {
-                    let (mut tx, signing_data, tx_args) =
-                        build_tx_shielded_transfer(sdk, source, target, amount, settings).await?;
-                    execute_tx_shielded_transfer(sdk, &mut tx, signing_data, &tx_args).await?
-                }
-                Task::Shielding(source, target, amount, settings) => {
-                    let (mut tx, signing_data, tx_args) =
-                        build_tx_shielding(sdk, source, target, amount, settings).await?;
-                    execute_tx_shielding(sdk, &mut tx, signing_data, &tx_args).await?
-                }
-                Task::Unshielding(source, target, amount, settings) => {
-                    let (mut tx, signing_data, tx_args) =
-                        build_tx_unshielding(sdk, source, target, amount, settings).await?;
-                    execute_tx_unshielding(sdk, &mut tx, signing_data, &tx_args).await?
-                }
-                Task::DeactivateValidator(target, settings) => {
-                    let (mut tx, signing_data, tx_args) =
-                        build_tx_deactivate_validator(sdk, target, settings).await?;
-                    execute_tx_deactivate_validator(sdk, &mut tx, signing_data, &tx_args).await?
-                }
-                Task::ReactivateValidator(target, settings) => {
-                    let (mut tx, signing_data, tx_args) =
-                        build_tx_reactivate_validator(sdk, target, settings).await?;
-                    execute_tx_reactivate_validator(sdk, &mut tx, signing_data, &tx_args).await?
-                }
-                Task::Vote(source, proposal_id, vote, settings) => {
-                    let (mut tx, signing_data, tx_args) =
-                        build_tx_vote(sdk, source, proposal_id, vote, settings).await?;
-                    execute_tx_vote(sdk, &mut tx, signing_data, &tx_args).await?
-                }
-                Task::ChangeMetadata(
-                    source,
-                    website,
-                    email,
-                    discord,
-                    description,
-                    avatar,
-                    settings,
-                ) => {
-                    let (mut tx, signing_data, tx_args) = build_tx_change_metadata(
-                        sdk,
-                        source,
-                        website,
-                        email,
-                        discord,
-                        description,
-                        avatar,
-                        settings,
-                    )
-                    .await?;
-                    execute_tx_shielding(sdk, &mut tx, signing_data, &tx_args).await?
-                }
-                Task::ChangeConsensusKeys(source, alias, settings) => {
-                    let (mut tx, signing_data, tx_args) =
-                        build_tx_change_consensus_key(sdk, source, alias, settings).await?;
-                    execute_tx_change_consensus_key(sdk, &mut tx, signing_data, &tx_args).await?
-                }
-                Task::UpdateAccount(target, sources, threshold, settings) => {
-                    let (mut tx, signing_data, tx_args) =
-                        build_tx_update_account(sdk, target, sources, threshold, settings).await?;
-                    execute_tx_update_account(sdk, &mut tx, signing_data, &tx_args).await?
-                }
-                Task::BecomeValidator(alias, t, t1, t2, t3, comm, max_comm_change, settings) => {
-                    let (mut tx, signing_data, tx_args) = build_tx_become_validator(
-                        sdk,
-                        alias,
-                        t,
-                        t1,
-                        t2,
-                        t3,
-                        comm,
-                        max_comm_change,
-                        settings,
-                    )
-                    .await?;
-                    execute_tx_shielding(sdk, &mut tx, signing_data, &tx_args).await?
-                }
-                Task::DefaultProposal(source, start_epoch, end_epoch, grace_epoch, settings) => {
-                    let (mut tx, signing_data, tx_args) = build_tx_default_proposal(
-                        sdk,
-                        source,
-                        start_epoch,
-                        end_epoch,
-                        grace_epoch,
-                        settings,
-                    )
-                    .await?;
-                    execute_tx_default_proposal(sdk, &mut tx, signing_data, &tx_args).await?
-                }
-                Task::Batch(tasks, task_settings) => {
-                    let mut txs = vec![];
-                    for task in tasks {
-                        let (tx, signing_data, _) = match task {
-                            Task::TransparentTransfer(source, target, amount, settings) => {
-                                build_tx_transparent_transfer(sdk, source, target, amount, settings)
-                                    .await?
-                            }
-                            Task::Bond(source, validator, amount, _epoch, settings) => {
-                                build_tx_bond(sdk, source, validator, amount, settings).await?
-                            }
-                            Task::Redelegate(source, from, to, amount, _epoch, task_settings) => {
-                                build_tx_redelegate(sdk, source, from, to, amount, task_settings)
-                                    .await?
-                            }
-                            Task::Unbond(source, validator, amount, _epoch, settings) => {
-                                build_tx_unbond(sdk, source, validator, amount, settings).await?
-                            }
-                            Task::ShieldedTransfer(source, target, amount, settings) => {
-                                build_tx_shielded_transfer(sdk, source, target, amount, settings)
-                                    .await?
-                            }
-                            Task::Shielding(source, target, amount, settings) => {
-                                build_tx_shielding(sdk, source, target, amount, settings).await?
-                            }
-                            Task::ClaimRewards(source, validator, settings) => {
-                                build_tx_claim_rewards(sdk, source, validator, settings).await?
-                            }
-                            _ => panic!(),
-                        };
-                        txs.push((tx, signing_data));
-                    }
-
-                    execute_tx_batch(sdk, txs, task_settings).await?
-                }
-            };
+            let execution_height = task.execute(sdk).await?;
             let execution_result = ExecutionResult {
                 time_taken: now.elapsed().as_secs(),
                 execution_height,

--- a/workload/src/steps.rs
+++ b/workload/src/steps.rs
@@ -27,6 +27,7 @@ use crate::{
     check::Check,
     constants::{MIN_TRANSFER_BALANCE, PROPOSAL_DEPOSIT},
     entities::Alias,
+    execute::reveal_pk::execute_reveal_pk,
     sdk::namada::Sdk,
     state::State,
     task::Task,

--- a/workload/src/steps.rs
+++ b/workload/src/steps.rs
@@ -366,7 +366,7 @@ impl WorkloadExecutor {
                     .await
                 }
                 Task::DefaultProposal(source, _start_epoch, _end_epoch, _grace_epoch, _) => {
-                    build_checks::proposal::proposal(sdk, source, retry_config, state).await
+                    build_checks::proposal::proposal(sdk, source, retry_config).await
                 }
                 Task::Vote(_, _, _, _) => {
                     vec![]

--- a/workload/src/task.rs
+++ b/workload/src/task.rs
@@ -2,7 +2,35 @@ use std::{collections::BTreeSet, fmt::Display};
 
 use namada_sdk::dec::Dec;
 
-use crate::{constants::DEFAULT_GAS_LIMIT, entities::Alias};
+use crate::{
+    constants::DEFAULT_GAS_LIMIT,
+    entities::Alias,
+    execute::{
+        batch::execute_tx_batch,
+        become_validator::build_tx_become_validator,
+        bond::{build_tx_bond, execute_tx_bond},
+        change_consensus_keys::{build_tx_change_consensus_key, execute_tx_change_consensus_key},
+        change_metadata::build_tx_change_metadata,
+        claim_rewards::{build_tx_claim_rewards, execute_tx_claim_rewards},
+        deactivate_validator::{build_tx_deactivate_validator, execute_tx_deactivate_validator},
+        default_proposal::{build_tx_default_proposal, execute_tx_default_proposal},
+        faucet_transfer::execute_faucet_transfer,
+        init_account::{build_tx_init_account, execute_tx_init_account},
+        new_wallet_keypair::execute_new_wallet_key_pair,
+        reactivate_validator::{build_tx_reactivate_validator, execute_tx_reactivate_validator},
+        redelegate::{build_tx_redelegate, execute_tx_redelegate},
+        reveal_pk::execute_reveal_pk,
+        shielded::{build_tx_shielded_transfer, execute_tx_shielded_transfer},
+        shielding::{build_tx_shielding, execute_tx_shielding},
+        transparent_transfer::execute_tx_transparent_transfer,
+        unbond::{build_tx_unbond, execute_tx_unbond},
+        unshielding::{build_tx_unshielding, execute_tx_unshielding},
+        update_account::{build_tx_update_account, execute_tx_update_account},
+        vote::{build_tx_vote, execute_tx_vote},
+    },
+    sdk::namada::Sdk,
+    steps::StepError,
+};
 
 #[derive(Clone, Debug)]
 pub struct TaskSettings {
@@ -106,6 +134,151 @@ impl Task {
             Task::ReactivateValidator(_, _) => "reactivate-validator".to_string(),
             Task::DefaultProposal(_, _, _, _, _) => "default-proposal".to_string(),
             Task::Vote(_, _, _, _) => "vote-proposal".to_string(),
+        }
+    }
+
+    pub async fn execute(&self, sdk: &Sdk) -> Result<Option<u64>, StepError> {
+        match self {
+            Task::NewWalletKeyPair(alias) => {
+                let public_key = execute_new_wallet_key_pair(sdk, alias).await?;
+                execute_reveal_pk(sdk, public_key).await
+            }
+            Task::FaucetTransfer(target, amount, settings) => {
+                execute_faucet_transfer(sdk, target, *amount, settings).await
+            }
+            Task::TransparentTransfer(source, target, amount, settings) => {
+                execute_tx_transparent_transfer(sdk, source, target, *amount, settings).await
+            }
+            Task::Bond(source, validator, amount, _epoch, settings) => {
+                execute_tx_bond(sdk, source, validator, *amount, settings).await
+            }
+            Task::InitAccount(source, sources, threshold, settings) => {
+                execute_tx_init_account(sdk, source, sources, *threshold, settings).await
+            }
+            Task::Redelegate(source, from, to, amount, _epoch, settings) => {
+                execute_tx_redelegate(sdk, source, from, to, *amount, settings).await
+            }
+            Task::Unbond(source, validator, amount, _epoch, settings) => {
+                execute_tx_unbond(sdk, source, validator, *amount, settings).await
+            }
+            Task::ClaimRewards(source, validator, settings) => {
+                execute_tx_claim_rewards(sdk, source, validator, settings).await
+            }
+            Task::ShieldedTransfer(source, target, amount, settings) => {
+                execute_tx_shielded_transfer(sdk, source, target, *amount, settings).await
+            }
+            Task::Shielding(source, target, amount, settings) => {
+                execute_tx_shielding(sdk, source, target, *amount, settings).await
+            }
+            Task::Unshielding(source, target, amount, settings) => {
+                execute_tx_unshielding(sdk, source, target, *amount, settings).await
+            }
+            Task::DeactivateValidator(target, settings) => {
+                let (mut tx, signing_data, tx_args) =
+                    build_tx_deactivate_validator(sdk, target, settings).await?;
+                execute_tx_deactivate_validator(sdk, &mut tx, signing_data, &tx_args).await?
+            }
+            Task::ReactivateValidator(target, settings) => {
+                let (mut tx, signing_data, tx_args) =
+                    build_tx_reactivate_validator(sdk, target, settings).await?;
+                execute_tx_reactivate_validator(sdk, &mut tx, signing_data, &tx_args).await?
+            }
+            Task::Vote(source, proposal_id, vote, settings) => {
+                execute_tx_vote(sdk, source, *proposal_id, vote, settings).await
+            }
+            Task::ChangeMetadata(
+                source,
+                website,
+                email,
+                discord,
+                description,
+                avatar,
+                settings,
+            ) => {
+                let (mut tx, signing_data, tx_args) = build_tx_change_metadata(
+                    sdk,
+                    source,
+                    website,
+                    email,
+                    discord,
+                    description,
+                    avatar,
+                    settings,
+                )
+                .await?;
+                execute_tx_shielding(sdk, &mut tx, signing_data, &tx_args).await?
+            }
+            Task::ChangeConsensusKeys(source, alias, settings) => {
+                let (mut tx, signing_data, tx_args) =
+                    build_tx_change_consensus_key(sdk, source, alias, settings).await?;
+                execute_tx_change_consensus_key(sdk, &mut tx, signing_data, &tx_args).await?
+            }
+            Task::UpdateAccount(target, sources, threshold, settings) => {
+                let (mut tx, signing_data, tx_args) =
+                    build_tx_update_account(sdk, target, sources, threshold, settings).await?;
+                execute_tx_update_account(sdk, &mut tx, signing_data, &tx_args).await?
+            }
+            Task::BecomeValidator(alias, t, t1, t2, t3, comm, max_comm_change, settings) => {
+                let (mut tx, signing_data, tx_args) = build_tx_become_validator(
+                    sdk,
+                    alias,
+                    t,
+                    t1,
+                    t2,
+                    t3,
+                    comm,
+                    max_comm_change,
+                    settings,
+                )
+                .await?;
+                execute_tx_shielding(sdk, &mut tx, signing_data, &tx_args).await?
+            }
+            Task::DefaultProposal(source, start_epoch, end_epoch, grace_epoch, settings) => {
+                execute_tx_default_proposal(
+                    sdk,
+                    source,
+                    *start_epoch,
+                    *end_epoch,
+                    *grace_epoch,
+                    settings,
+                )
+                .await
+            }
+            Task::Batch(tasks, task_settings) => {
+                let mut txs = vec![];
+                for task in tasks {
+                    let (tx, signing_data, _) = match task {
+                        Task::TransparentTransfer(source, target, amount, settings) => {
+                            build_tx_transparent_transfer(sdk, source, target, amount, settings)
+                                .await?
+                        }
+                        Task::Bond(source, validator, amount, _epoch, settings) => {
+                            build_tx_bond(sdk, source, validator, amount, settings).await?
+                        }
+                        Task::Redelegate(source, from, to, amount, _epoch, task_settings) => {
+                            build_tx_redelegate(sdk, source, from, to, amount, task_settings)
+                                .await?
+                        }
+                        Task::Unbond(source, validator, amount, _epoch, settings) => {
+                            build_tx_unbond(sdk, source, validator, amount, settings).await?
+                        }
+                        Task::ShieldedTransfer(source, target, amount, settings) => {
+                            build_tx_shielded_transfer(sdk, source, target, amount, settings)
+                                .await?
+                        }
+                        Task::Shielding(source, target, amount, settings) => {
+                            build_tx_shielding(sdk, source, target, amount, settings).await?
+                        }
+                        Task::ClaimRewards(source, validator, settings) => {
+                            build_tx_claim_rewards(sdk, source, validator, settings).await?
+                        }
+                        _ => panic!(),
+                    };
+                    txs.push((tx, signing_data));
+                }
+
+                execute_tx_batch(sdk, txs, task_settings).await?
+            }
         }
     }
 }

--- a/workload/src/task.rs
+++ b/workload/src/task.rs
@@ -7,26 +7,26 @@ use crate::{
     entities::Alias,
     execute::{
         batch::execute_tx_batch,
-        become_validator::build_tx_become_validator,
+        become_validator::execute_tx_become_validator,
         bond::{build_tx_bond, execute_tx_bond},
-        change_consensus_keys::{build_tx_change_consensus_key, execute_tx_change_consensus_key},
-        change_metadata::build_tx_change_metadata,
+        change_consensus_keys::execute_tx_change_consensus_key,
+        change_metadata::execute_tx_change_metadata,
         claim_rewards::{build_tx_claim_rewards, execute_tx_claim_rewards},
-        deactivate_validator::{build_tx_deactivate_validator, execute_tx_deactivate_validator},
-        default_proposal::{build_tx_default_proposal, execute_tx_default_proposal},
+        deactivate_validator::execute_tx_deactivate_validator,
+        default_proposal::execute_tx_default_proposal,
         faucet_transfer::execute_faucet_transfer,
-        init_account::{build_tx_init_account, execute_tx_init_account},
+        init_account::execute_tx_init_account,
         new_wallet_keypair::execute_new_wallet_key_pair,
-        reactivate_validator::{build_tx_reactivate_validator, execute_tx_reactivate_validator},
+        reactivate_validator::execute_tx_reactivate_validator,
         redelegate::{build_tx_redelegate, execute_tx_redelegate},
         reveal_pk::execute_reveal_pk,
         shielded::{build_tx_shielded_transfer, execute_tx_shielded_transfer},
         shielding::{build_tx_shielding, execute_tx_shielding},
-        transparent_transfer::execute_tx_transparent_transfer,
+        transparent_transfer::{build_tx_transparent_transfer, execute_tx_transparent_transfer},
         unbond::{build_tx_unbond, execute_tx_unbond},
-        unshielding::{build_tx_unshielding, execute_tx_unshielding},
-        update_account::{build_tx_update_account, execute_tx_update_account},
-        vote::{build_tx_vote, execute_tx_vote},
+        unshielding::execute_tx_unshielding,
+        update_account::execute_tx_update_account,
+        vote::execute_tx_vote,
     },
     sdk::namada::Sdk,
     steps::StepError,
@@ -174,14 +174,10 @@ impl Task {
                 execute_tx_unshielding(sdk, source, target, *amount, settings).await
             }
             Task::DeactivateValidator(target, settings) => {
-                let (mut tx, signing_data, tx_args) =
-                    build_tx_deactivate_validator(sdk, target, settings).await?;
-                execute_tx_deactivate_validator(sdk, &mut tx, signing_data, &tx_args).await?
+                execute_tx_deactivate_validator(sdk, target, settings).await
             }
             Task::ReactivateValidator(target, settings) => {
-                let (mut tx, signing_data, tx_args) =
-                    build_tx_reactivate_validator(sdk, target, settings).await?;
-                execute_tx_reactivate_validator(sdk, &mut tx, signing_data, &tx_args).await?
+                execute_tx_reactivate_validator(sdk, target, settings).await
             }
             Task::Vote(source, proposal_id, vote, settings) => {
                 execute_tx_vote(sdk, source, *proposal_id, vote, settings).await
@@ -195,7 +191,7 @@ impl Task {
                 avatar,
                 settings,
             ) => {
-                let (mut tx, signing_data, tx_args) = build_tx_change_metadata(
+                execute_tx_change_metadata(
                     sdk,
                     source,
                     website,
@@ -205,33 +201,27 @@ impl Task {
                     avatar,
                     settings,
                 )
-                .await?;
-                execute_tx_shielding(sdk, &mut tx, signing_data, &tx_args).await?
+                .await
             }
             Task::ChangeConsensusKeys(source, alias, settings) => {
-                let (mut tx, signing_data, tx_args) =
-                    build_tx_change_consensus_key(sdk, source, alias, settings).await?;
-                execute_tx_change_consensus_key(sdk, &mut tx, signing_data, &tx_args).await?
+                execute_tx_change_consensus_key(sdk, source, alias, settings).await
             }
             Task::UpdateAccount(target, sources, threshold, settings) => {
-                let (mut tx, signing_data, tx_args) =
-                    build_tx_update_account(sdk, target, sources, threshold, settings).await?;
-                execute_tx_update_account(sdk, &mut tx, signing_data, &tx_args).await?
+                execute_tx_update_account(sdk, target, sources, *threshold, settings).await
             }
             Task::BecomeValidator(alias, t, t1, t2, t3, comm, max_comm_change, settings) => {
-                let (mut tx, signing_data, tx_args) = build_tx_become_validator(
+                execute_tx_become_validator(
                     sdk,
                     alias,
                     t,
                     t1,
                     t2,
                     t3,
-                    comm,
-                    max_comm_change,
+                    *comm,
+                    *max_comm_change,
                     settings,
                 )
-                .await?;
-                execute_tx_shielding(sdk, &mut tx, signing_data, &tx_args).await?
+                .await
             }
             Task::DefaultProposal(source, start_epoch, end_epoch, grace_epoch, settings) => {
                 execute_tx_default_proposal(
@@ -249,25 +239,25 @@ impl Task {
                 for task in tasks {
                     let (tx, signing_data, _) = match task {
                         Task::TransparentTransfer(source, target, amount, settings) => {
-                            build_tx_transparent_transfer(sdk, source, target, amount, settings)
+                            build_tx_transparent_transfer(sdk, source, target, *amount, settings)
                                 .await?
                         }
                         Task::Bond(source, validator, amount, _epoch, settings) => {
-                            build_tx_bond(sdk, source, validator, amount, settings).await?
+                            build_tx_bond(sdk, source, validator, *amount, settings).await?
                         }
                         Task::Redelegate(source, from, to, amount, _epoch, task_settings) => {
-                            build_tx_redelegate(sdk, source, from, to, amount, task_settings)
+                            build_tx_redelegate(sdk, source, from, to, *amount, task_settings)
                                 .await?
                         }
                         Task::Unbond(source, validator, amount, _epoch, settings) => {
-                            build_tx_unbond(sdk, source, validator, amount, settings).await?
+                            build_tx_unbond(sdk, source, validator, *amount, settings).await?
                         }
                         Task::ShieldedTransfer(source, target, amount, settings) => {
-                            build_tx_shielded_transfer(sdk, source, target, amount, settings)
+                            build_tx_shielded_transfer(sdk, source, target, *amount, settings)
                                 .await?
                         }
                         Task::Shielding(source, target, amount, settings) => {
-                            build_tx_shielding(sdk, source, target, amount, settings).await?
+                            build_tx_shielding(sdk, source, target, *amount, settings).await?
                         }
                         Task::ClaimRewards(source, validator, settings) => {
                             build_tx_claim_rewards(sdk, source, validator, settings).await?
@@ -277,7 +267,7 @@ impl Task {
                     txs.push((tx, signing_data));
                 }
 
-                execute_tx_batch(sdk, txs, task_settings).await?
+                execute_tx_batch(sdk, txs, task_settings).await
             }
         }
     }


### PR DESCRIPTION
The refactoring is in progress, but it would be bigger. So, I'd like to open this PR at this point.
This mainly targets `main`, `state`, `task`, and `execute` modules in `workload`.
Especially,
- Tidy `exit_code` up
- Reduce clone()
- Error handling (many `unwrap()` are still left)