### PR TITLE
Fix broadcast failure

### DIFF
--- a/workload/scripts/parallel_driver_become_validator.sh
+++ b/workload/scripts/parallel_driver_become_validator.sh
@@ -5,7 +5,4 @@ set -e
 CHAIN_ID=$(find /container_ready -type f -name "devnet*")
 CHAIN_ID=$(basename $CHAIN_ID)
 
-echo "Workload: the chain ID is $CHAIN_ID"
-echo "Using rpc: ${RPC}"
-
 /app/namada-chain-workload --rpc http://${RPC} --chain-id ${CHAIN_ID} --faucet-sk ${FAUCET_SK} --id ${WORKLOAD_ID} --masp-indexer-url ${MASP_INDEXER_URL} become-validator

--- a/workload/scripts/parallel_driver_bond.sh
+++ b/workload/scripts/parallel_driver_bond.sh
@@ -5,7 +5,4 @@ set -e
 CHAIN_ID=$(find /container_ready -type f -name "devnet*")
 CHAIN_ID=$(basename $CHAIN_ID)
 
-echo "Workload: the chain ID is $CHAIN_ID"
-echo "Using rpc: ${RPC}"
-
 /app/namada-chain-workload --rpc http://${RPC} --chain-id ${CHAIN_ID} --faucet-sk ${FAUCET_SK} --id ${WORKLOAD_ID} --masp-indexer-url ${MASP_INDEXER_URL} bond

--- a/workload/scripts/parallel_driver_bond_batch.sh
+++ b/workload/scripts/parallel_driver_bond_batch.sh
@@ -5,7 +5,4 @@ set -e
 CHAIN_ID=$(find /container_ready -type f -name "devnet*")
 CHAIN_ID=$(basename $CHAIN_ID)
 
-echo "Workload: the chain ID is $CHAIN_ID"
-echo "Using rpc: ${RPC}"
-
 /app/namada-chain-workload --rpc http://${RPC} --chain-id ${CHAIN_ID} --faucet-sk ${FAUCET_SK} --id ${WORKLOAD_ID} --masp-indexer-url ${MASP_INDEXER_URL} batch-bond

--- a/workload/scripts/parallel_driver_change_consensus_keys.sh
+++ b/workload/scripts/parallel_driver_change_consensus_keys.sh
@@ -5,7 +5,4 @@ set -e
 CHAIN_ID=$(find /container_ready -type f -name "devnet*")
 CHAIN_ID=$(basename $CHAIN_ID)
 
-echo "Workload: the chain ID is $CHAIN_ID"
-echo "Using rpc: ${RPC}"
-
 /app/namada-chain-workload --rpc http://${RPC} --chain-id ${CHAIN_ID} --faucet-sk ${FAUCET_SK} --id ${WORKLOAD_ID} --masp-indexer-url ${MASP_INDEXER_URL} change-consensus-key

--- a/workload/scripts/parallel_driver_change_metadata.sh
+++ b/workload/scripts/parallel_driver_change_metadata.sh
@@ -5,7 +5,4 @@ set -e
 CHAIN_ID=$(find /container_ready -type f -name "devnet*")
 CHAIN_ID=$(basename $CHAIN_ID)
 
-echo "Workload: the chain ID is $CHAIN_ID"
-echo "Using rpc: ${RPC}"
-
 /app/namada-chain-workload --rpc http://${RPC} --chain-id ${CHAIN_ID} --faucet-sk ${FAUCET_SK} --id ${WORKLOAD_ID} --masp-indexer-url ${MASP_INDEXER_URL} change-metadata

--- a/workload/scripts/parallel_driver_claim_rewards.sh
+++ b/workload/scripts/parallel_driver_claim_rewards.sh
@@ -5,7 +5,4 @@ set -e
 CHAIN_ID=$(find /container_ready -type f -name "devnet*")
 CHAIN_ID=$(basename $CHAIN_ID)
 
-echo "Workload: the chain ID is $CHAIN_ID"
-echo "Using rpc: ${RPC}"
-
 /app/namada-chain-workload --rpc http://${RPC} --chain-id ${CHAIN_ID} --faucet-sk ${FAUCET_SK} --id ${WORKLOAD_ID} --masp-indexer-url ${MASP_INDEXER_URL} claim-rewards

--- a/workload/scripts/parallel_driver_create_wallet.sh
+++ b/workload/scripts/parallel_driver_create_wallet.sh
@@ -5,7 +5,4 @@ set -e
 CHAIN_ID=$(find /container_ready -type f -name "devnet*")
 CHAIN_ID=$(basename $CHAIN_ID)
 
-echo "Workload: the chain ID is $CHAIN_ID"
-echo "Using rpc: ${RPC}"
-
 /app/namada-chain-workload --rpc http://${RPC} --chain-id ${CHAIN_ID} --faucet-sk ${FAUCET_SK} --id ${WORKLOAD_ID} --masp-indexer-url ${MASP_INDEXER_URL} new-wallet-key-pair

--- a/workload/scripts/parallel_driver_deactivate_validator.sh
+++ b/workload/scripts/parallel_driver_deactivate_validator.sh
@@ -5,7 +5,4 @@ set -e
 CHAIN_ID=$(find /container_ready -type f -name "devnet*")
 CHAIN_ID=$(basename $CHAIN_ID)
 
-echo "Workload: the chain ID is $CHAIN_ID"
-echo "Using rpc: ${RPC}"
-
 /app/namada-chain-workload --rpc http://${RPC} --chain-id ${CHAIN_ID} --faucet-sk ${FAUCET_SK} --id ${WORKLOAD_ID} --masp-indexer-url ${MASP_INDEXER_URL} deactivate-validator

--- a/workload/scripts/parallel_driver_default_proposal.sh
+++ b/workload/scripts/parallel_driver_default_proposal.sh
@@ -5,7 +5,4 @@ set -e
 CHAIN_ID=$(find /container_ready -type f -name "devnet*")
 CHAIN_ID=$(basename $CHAIN_ID)
 
-echo "Workload: the chain ID is $CHAIN_ID"
-echo "Using rpc: ${RPC}"
-
 /app/namada-chain-workload --rpc http://${RPC} --chain-id ${CHAIN_ID} --faucet-sk ${FAUCET_SK} --id ${WORKLOAD_ID} --masp-indexer-url ${MASP_INDEXER_URL} default-proposal

--- a/workload/scripts/parallel_driver_faucet_transfer.sh
+++ b/workload/scripts/parallel_driver_faucet_transfer.sh
@@ -5,7 +5,4 @@ set -e
 CHAIN_ID=$(find /container_ready -type f -name "devnet*")
 CHAIN_ID=$(basename $CHAIN_ID)
 
-echo "Workload: the chain ID is $CHAIN_ID"
-echo "Using rpc: ${RPC}"
-
 /app/namada-chain-workload --rpc http://${RPC} --chain-id ${CHAIN_ID} --faucet-sk ${FAUCET_SK} --id ${WORKLOAD_ID} --masp-indexer-url ${MASP_INDEXER_URL} faucet-transfer

--- a/workload/scripts/parallel_driver_init_account.sh
+++ b/workload/scripts/parallel_driver_init_account.sh
@@ -5,7 +5,4 @@ set -e
 CHAIN_ID=$(find /container_ready -type f -name "devnet*")
 CHAIN_ID=$(basename $CHAIN_ID)
 
-echo "Workload: the chain ID is $CHAIN_ID"
-echo "Using rpc: ${RPC}"
-
 /app/namada-chain-workload --rpc http://${RPC} --chain-id ${CHAIN_ID} --faucet-sk ${FAUCET_SK} --id ${WORKLOAD_ID} --masp-indexer-url ${MASP_INDEXER_URL} init-account

--- a/workload/scripts/parallel_driver_random_batch.sh
+++ b/workload/scripts/parallel_driver_random_batch.sh
@@ -5,7 +5,4 @@ set -e
 CHAIN_ID=$(find /container_ready -type f -name "devnet*")
 CHAIN_ID=$(basename $CHAIN_ID)
 
-echo "Workload: the chain ID is $CHAIN_ID"
-echo "Using rpc: ${RPC}"
-
 /app/namada-chain-workload --rpc http://${RPC} --chain-id ${CHAIN_ID} --faucet-sk ${FAUCET_SK} --id ${WORKLOAD_ID} --masp-indexer-url ${MASP_INDEXER_URL} batch-random

--- a/workload/scripts/parallel_driver_reactivate_validator.sh
+++ b/workload/scripts/parallel_driver_reactivate_validator.sh
@@ -5,7 +5,4 @@ set -e
 CHAIN_ID=$(find /container_ready -type f -name "devnet*")
 CHAIN_ID=$(basename $CHAIN_ID)
 
-echo "Workload: the chain ID is $CHAIN_ID"
-echo "Using rpc: ${RPC}"
-
 /app/namada-chain-workload --rpc http://${RPC} --chain-id ${CHAIN_ID} --faucet-sk ${FAUCET_SK} --id ${WORKLOAD_ID} --masp-indexer-url ${MASP_INDEXER_URL} reactivate-validator

--- a/workload/scripts/parallel_driver_redelegate.sh
+++ b/workload/scripts/parallel_driver_redelegate.sh
@@ -5,7 +5,4 @@ set -e
 CHAIN_ID=$(find /container_ready -type f -name "devnet*")
 CHAIN_ID=$(basename $CHAIN_ID)
 
-echo "Workload: the chain ID is $CHAIN_ID"
-echo "Using rpc: ${RPC}"
-
 /app/namada-chain-workload --rpc http://${RPC} --chain-id ${CHAIN_ID} --faucet-sk ${FAUCET_SK} --id ${WORKLOAD_ID} --masp-indexer-url ${MASP_INDEXER_URL} redelegate

--- a/workload/scripts/parallel_driver_shielded.sh
+++ b/workload/scripts/parallel_driver_shielded.sh
@@ -5,7 +5,4 @@ set -e
 CHAIN_ID=$(find /container_ready -type f -name "devnet*")
 CHAIN_ID=$(basename $CHAIN_ID)
 
-echo "Workload: the chain ID is $CHAIN_ID"
-echo "Using rpc: ${RPC}"
-
 /app/namada-chain-workload --rpc http://${RPC} --chain-id ${CHAIN_ID} --faucet-sk ${FAUCET_SK} --id ${WORKLOAD_ID} --masp-indexer-url ${MASP_INDEXER_URL} shielded

--- a/workload/scripts/parallel_driver_shielding.sh
+++ b/workload/scripts/parallel_driver_shielding.sh
@@ -5,7 +5,4 @@ set -e
 CHAIN_ID=$(find /container_ready -type f -name "devnet*")
 CHAIN_ID=$(basename $CHAIN_ID)
 
-echo "Workload: the chain ID is $CHAIN_ID"
-echo "Using rpc: ${RPC}"
-
 /app/namada-chain-workload --rpc http://${RPC} --chain-id ${CHAIN_ID} --faucet-sk ${FAUCET_SK} --id ${WORKLOAD_ID} --masp-indexer-url ${MASP_INDEXER_URL} shielding

--- a/workload/scripts/parallel_driver_transparent_transfer.sh
+++ b/workload/scripts/parallel_driver_transparent_transfer.sh
@@ -5,7 +5,4 @@ set -e
 CHAIN_ID=$(find /container_ready -type f -name "devnet*")
 CHAIN_ID=$(basename $CHAIN_ID)
 
-echo "Workload: the chain ID is $CHAIN_ID"
-echo "Using rpc: ${RPC}"
-
 /app/namada-chain-workload --rpc http://${RPC} --chain-id ${CHAIN_ID} --faucet-sk ${FAUCET_SK} --id ${WORKLOAD_ID} --masp-indexer-url ${MASP_INDEXER_URL} transparent-transfer

--- a/workload/scripts/parallel_driver_unbond.sh
+++ b/workload/scripts/parallel_driver_unbond.sh
@@ -5,7 +5,4 @@ set -e
 CHAIN_ID=$(find /container_ready -type f -name "devnet*")
 CHAIN_ID=$(basename $CHAIN_ID)
 
-echo "Workload: the chain ID is $CHAIN_ID"
-echo "Using rpc: ${RPC}"
-
 /app/namada-chain-workload --rpc http://${RPC} --chain-id ${CHAIN_ID} --faucet-sk ${FAUCET_SK} --id ${WORKLOAD_ID} --masp-indexer-url ${MASP_INDEXER_URL} unbond

--- a/workload/scripts/parallel_driver_unshielding.sh
+++ b/workload/scripts/parallel_driver_unshielding.sh
@@ -5,7 +5,4 @@ set -e
 CHAIN_ID=$(find /container_ready -type f -name "devnet*")
 CHAIN_ID=$(basename $CHAIN_ID)
 
-echo "Workload: the chain ID is $CHAIN_ID"
-echo "Using rpc: ${RPC}"
-
 /app/namada-chain-workload --rpc http://${RPC} --chain-id ${CHAIN_ID} --faucet-sk ${FAUCET_SK} --id ${WORKLOAD_ID} --masp-indexer-url ${MASP_INDEXER_URL} unshielding

--- a/workload/scripts/parallel_driver_update_account.sh
+++ b/workload/scripts/parallel_driver_update_account.sh
@@ -5,7 +5,4 @@ set -e
 CHAIN_ID=$(find /container_ready -type f -name "devnet*")
 CHAIN_ID=$(basename $CHAIN_ID)
 
-echo "Workload: the chain ID is $CHAIN_ID"
-echo "Using rpc: ${RPC}"
-
 /app/namada-chain-workload --rpc http://${RPC} --chain-id ${CHAIN_ID} --faucet-sk ${FAUCET_SK} --id ${WORKLOAD_ID} --masp-indexer-url ${MASP_INDEXER_URL} update-account

--- a/workload/scripts/parallel_driver_vote.sh
+++ b/workload/scripts/parallel_driver_vote.sh
@@ -5,7 +5,4 @@ set -e
 CHAIN_ID=$(find /container_ready -type f -name "devnet*")
 CHAIN_ID=$(basename $CHAIN_ID)
 
-echo "Workload: the chain ID is $CHAIN_ID"
-echo "Using rpc: ${RPC}"
-
 /app/namada-chain-workload --rpc http://${RPC} --chain-id ${CHAIN_ID} --faucet-sk ${FAUCET_SK} --id ${WORKLOAD_ID} --masp-indexer-url ${MASP_INDEXER_URL} vote

--- a/workload/src/main.rs
+++ b/workload/src/main.rs
@@ -52,15 +52,6 @@ async fn inner_main() -> Code {
     rlimit::increase_nofile_limit(u64::MAX).unwrap();
 
     let config = AppConfig::parse();
-    tracing::info!("Using config: {:#?}", config);
-    tracing::info!("Sha commit: {}", env!("VERGEN_GIT_SHA").to_string());
-
-    // just to report the workload version
-    antithesis_sdk::assert_always!(
-        true,
-        "ID should be greater than 0",
-        &json!({"commit_sha": env!("VERGEN_GIT_SHA")})
-    );
 
     let (state, locked_file) = match State::load(config.id) {
         Ok(result) => result,
@@ -74,7 +65,17 @@ async fn inner_main() -> Code {
         Err(e) => return Code::StateFatal(e),
     };
 
-    tracing::info!("Using base dir: {}", state.base_dir.as_path().display());
+    tracing::info!("Using config: {:#?}", config);
+
+    // just to report the workload version
+    antithesis_sdk::assert_always!(
+        true,
+        "ID should be greater than 0",
+        &json!({
+            "base dir": state.base_dir.to_string_lossy().into_owned(),
+            "commit_sha": env!("VERGEN_GIT_SHA")
+        })
+    );
 
     let url = Url::from_str(&config.rpc).expect("invalid RPC address");
     tracing::debug!("Opening connection to {url}");


### PR DESCRIPTION
When the transaction status query in `submit_tx` timed out, the tx might succeed.
It should be rechecked and the result. However, it returned `StepError::Broadcast` error immediately and the workload state was stale when the tx was applied successfully. Especially, the fault injection caused the query time out.

This PR added the recheck for the tx status.
And, it includes tidying up some logs shown before acquiring the lock of the state file that confused us.