### PR TITLE
Fix not to return Fatal code when other failures

### DIFF
--- a/workload/src/check/balance_shielded_source.rs
+++ b/workload/src/check/balance_shielded_source.rs
@@ -20,6 +20,10 @@ impl BalanceShieldedSource {
         &self.target
     }
 
+    pub fn pre_balance(&self) -> Balance {
+        self.pre_balance
+    }
+
     pub fn amount(&self) -> Amount {
         self.amount
     }

--- a/workload/src/check/balance_shielded_source.rs
+++ b/workload/src/check/balance_shielded_source.rs
@@ -34,27 +34,32 @@ impl CheckContext for BalanceShieldedSource {
         &self,
         sdk: &Sdk,
         check_info: CheckInfo,
-        _retry_config: RetryConfig,
+        retry_config: RetryConfig,
     ) -> Result<(), StepError> {
-        let post_balance =
-            get_shielded_balance(sdk, &self.target, Some(check_info.execution_height), true)
-                .await?
-                .ok_or_else(|| {
-                    antithesis_sdk::assert_unreachable!(
-                        "BalanceShieldedSource target doesn't exist.",
-                        &json!({
-                            "source_alias": self.target,
-                            "pre_balance": self.pre_balance,
-                            "amount": self.amount,
-                            "execution_height": check_info.execution_height,
-                            "check_height": check_info.check_height,
-                        })
-                    );
-                    StepError::StateCheck(format!(
-                        "BalanceShieldedSource check error: {} balance doesn't exist",
-                        self.target.name
-                    ))
-                })?;
+        let post_balance = get_shielded_balance(
+            sdk,
+            &self.target,
+            Some(check_info.execution_height),
+            true,
+            retry_config,
+        )
+        .await?
+        .ok_or_else(|| {
+            antithesis_sdk::assert_unreachable!(
+                "BalanceShieldedSource target doesn't exist.",
+                &json!({
+                    "source_alias": self.target,
+                    "pre_balance": self.pre_balance,
+                    "amount": self.amount,
+                    "execution_height": check_info.execution_height,
+                    "check_height": check_info.check_height,
+                })
+            );
+            StepError::StateCheck(format!(
+                "BalanceShieldedSource check error: {} balance doesn't exist",
+                self.target.name
+            ))
+        })?;
 
         let check_balance = self
             .pre_balance

--- a/workload/src/check/balance_shielded_target.rs
+++ b/workload/src/check/balance_shielded_target.rs
@@ -20,6 +20,10 @@ impl BalanceShieldedTarget {
         &self.target
     }
 
+    pub fn pre_balance(&self) -> Balance {
+        self.pre_balance
+    }
+
     pub fn amount(&self) -> Amount {
         self.amount
     }

--- a/workload/src/check/balance_shielded_target.rs
+++ b/workload/src/check/balance_shielded_target.rs
@@ -34,27 +34,32 @@ impl CheckContext for BalanceShieldedTarget {
         &self,
         sdk: &Sdk,
         check_info: CheckInfo,
-        _retry_config: RetryConfig,
+        retry_config: RetryConfig,
     ) -> Result<(), StepError> {
-        let post_balance =
-            get_shielded_balance(sdk, &self.target, Some(check_info.execution_height), true)
-                .await?
-                .ok_or_else(|| {
-                    antithesis_sdk::assert_unreachable!(
-                        "BalanceShieldedTarget target doesn't exist.",
-                        &json!({
-                            "target_alias": self.target,
-                            "pre_balance": self.pre_balance,
-                            "amount": self.amount,
-                            "execution_height": check_info.execution_height,
-                            "check_height": check_info.check_height,
-                        })
-                    );
-                    StepError::StateCheck(format!(
-                        "BalanceShieldedTarget check error: {} balance doesn't exist",
-                        self.target.name
-                    ))
-                })?;
+        let post_balance = get_shielded_balance(
+            sdk,
+            &self.target,
+            Some(check_info.execution_height),
+            true,
+            retry_config,
+        )
+        .await?
+        .ok_or_else(|| {
+            antithesis_sdk::assert_unreachable!(
+                "BalanceShieldedTarget target doesn't exist.",
+                &json!({
+                    "target_alias": self.target,
+                    "pre_balance": self.pre_balance,
+                    "amount": self.amount,
+                    "execution_height": check_info.execution_height,
+                    "check_height": check_info.check_height,
+                })
+            );
+            StepError::StateCheck(format!(
+                "BalanceShieldedTarget check error: {} balance doesn't exist",
+                self.target.name
+            ))
+        })?;
 
         let check_balance = self
             .pre_balance

--- a/workload/src/check/balance_source.rs
+++ b/workload/src/check/balance_source.rs
@@ -20,6 +20,10 @@ impl BalanceSource {
         &self.target
     }
 
+    pub fn pre_balance(&self) -> Balance {
+        self.pre_balance
+    }
+
     pub fn amount(&self) -> Amount {
         self.amount
     }

--- a/workload/src/check/balance_target.rs
+++ b/workload/src/check/balance_target.rs
@@ -20,6 +20,10 @@ impl BalanceTarget {
         &self.target
     }
 
+    pub fn pre_balance(&self) -> Balance {
+        self.pre_balance
+    }
+
     pub fn amount(&self) -> Amount {
         self.amount
     }

--- a/workload/src/main.rs
+++ b/workload/src/main.rs
@@ -175,7 +175,8 @@ async fn inner_main() -> Code {
 
     let exit_code = match workload_executor.checks(checks, execution_height).await {
         Ok(_) => Code::Success(next_step),
-        Err(e) => Code::Fatal(next_step, e),
+        Err(e) if matches!(e, StepError::StateCheck(_)) => Code::Fatal(next_step, e),
+        Err(e) => Code::OtherFailure(next_step, e),
     };
 
     tracing::info!("Statistics: {:>?}", workload_executor.state().stats);

--- a/workload/src/task/batch.rs
+++ b/workload/src/task/batch.rs
@@ -178,7 +178,7 @@ impl TaskContext for Batch {
         }
 
         for (alias, amount) in shielded_balances {
-            let pre_balance = get_shielded_balance(sdk, &alias, None, true)
+            let pre_balance = get_shielded_balance(sdk, &alias, None, true, retry_config)
                 .await?
                 .unwrap_or_default();
             if amount >= 0 {

--- a/workload/src/task/shielded.rs
+++ b/workload/src/task/shielded.rs
@@ -105,9 +105,9 @@ impl TaskContext for ShieldedTransfer {
     async fn build_checks(
         &self,
         sdk: &Sdk,
-        _retry_config: RetryConfig,
+        retry_config: RetryConfig,
     ) -> Result<Vec<Check>, StepError> {
-        let pre_balance = get_shielded_balance(sdk, &self.source, None, false)
+        let pre_balance = get_shielded_balance(sdk, &self.source, None, false, retry_config)
             .await?
             .unwrap_or_default();
         let source_check = Check::BalanceShieldedSource(
@@ -118,7 +118,7 @@ impl TaskContext for ShieldedTransfer {
                 .build(),
         );
 
-        let pre_balance = get_shielded_balance(sdk, &self.target, None, false)
+        let pre_balance = get_shielded_balance(sdk, &self.target, None, false, retry_config)
             .await?
             .unwrap_or_default();
         let target_check = Check::BalanceShieldedTarget(

--- a/workload/src/task/shielding.rs
+++ b/workload/src/task/shielding.rs
@@ -111,7 +111,7 @@ impl TaskContext for Shielding {
                 .build(),
         );
 
-        let pre_balance = get_shielded_balance(sdk, &self.target, None, false)
+        let pre_balance = get_shielded_balance(sdk, &self.target, None, false, retry_config)
             .await?
             .unwrap_or_default();
         let target_check = Check::BalanceShieldedTarget(

--- a/workload/src/task/unshielding.rs
+++ b/workload/src/task/unshielding.rs
@@ -110,7 +110,7 @@ impl TaskContext for Unshielding {
         sdk: &Sdk,
         retry_config: RetryConfig,
     ) -> Result<Vec<Check>, StepError> {
-        let pre_balance = get_shielded_balance(sdk, &self.source, None, false)
+        let pre_balance = get_shielded_balance(sdk, &self.source, None, false, retry_config)
             .await?
             .unwrap_or_default();
         let source_check = Check::BalanceShieldedSource(


### PR DESCRIPTION
Also, 
- Refactoring for shielded sync
- Add retries in `get_shielded_balance`
- Add asserts to check if the pre-balance matched between the state and Namada state